### PR TITLE
Fix image upload when using G+-Photos app

### DIFF
--- a/app/src/main/java/org/matrix/matrixandroidsdk/activity/RoomActivity.java
+++ b/app/src/main/java/org/matrix/matrixandroidsdk/activity/RoomActivity.java
@@ -5,9 +5,8 @@ import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.v4.app.FragmentManager;
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
@@ -26,7 +25,6 @@ import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.ImageInfo;
 import org.matrix.androidsdk.rest.model.ImageMessage;
 import org.matrix.androidsdk.util.ContentManager;
-import org.matrix.androidsdk.util.ContentUtils;
 import org.matrix.androidsdk.util.JsonUtils;
 import org.matrix.matrixandroidsdk.ErrorListener;
 import org.matrix.matrixandroidsdk.Matrix;
@@ -36,9 +34,6 @@ import org.matrix.matrixandroidsdk.ViewedRoomTracker;
 import org.matrix.matrixandroidsdk.fragments.MatrixMessageListFragment;
 import org.matrix.matrixandroidsdk.fragments.RoomMembersDialogFragment;
 import org.matrix.matrixandroidsdk.util.ResourceUtils;
-
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 
 /**
  * Displays a single room with messages.
@@ -309,41 +304,34 @@ public class RoomActivity extends MXCActionBarActivity {
 
         if (resultCode == RESULT_OK) {
             if (requestCode == REQUEST_IMAGE) {
-                InputStream contentStream = null;
-                // Declare temporary variable for try/catch, assign to final later.
-                String tmpContentMimeType = null;
-                try {
-                    contentStream = getContentResolver().openInputStream(data.getData());
-                    tmpContentMimeType = getContentResolver().getType(data.getData());
-                } catch (FileNotFoundException e) {
-                    Log.e(LOG_TAG, "Failed to open image input stream", e);
+                final Uri imageUri = data.getData();
+                final ResourceUtils.Resource resource = ResourceUtils.openResource(this, imageUri);
+                if (resource == null) {
                     Toast.makeText(RoomActivity.this,
                             getString(R.string.message_failed_to_upload),
                             Toast.LENGTH_LONG).show();
                     return;
                 }
-                final String contentMimeType = tmpContentMimeType;
-                Log.d(LOG_TAG, "Selected image to upload: " + data.getData());
+                Log.d(LOG_TAG, "Selected image to upload: " + imageUri);
 
                 final ProgressDialog progressDialog = ProgressDialog.show(this, null, getString(R.string.message_uploading), true);
 
-                mSession.getContentManager().uploadContent(contentStream, contentMimeType, new ContentManager.UploadCallback() {
+                mSession.getContentManager().uploadContent(resource.contentStream, resource.mimeType, new ContentManager.UploadCallback() {
                     @Override
                     public void onUploadComplete(ContentResponse uploadResponse) {
                         if (uploadResponse == null) {
                             Toast.makeText(RoomActivity.this,
                                     getString(R.string.message_failed_to_upload),
                                     Toast.LENGTH_LONG).show();
-                        }
-                        else {
+                        } else {
                             Log.d(LOG_TAG, "Uploaded to " + uploadResponse.contentUri);
                             // Build the image message
                             ImageMessage message = new ImageMessage();
                             message.url = uploadResponse.contentUri;
-                            message.body = data.getDataString().substring(data.getDataString().lastIndexOf('/') + 1);
+                            message.body = imageUri.getLastPathSegment();
 
                             message.info = new ImageInfo();
-                            message.info.mimetype = contentMimeType;
+                            message.info.mimetype = resource.mimeType;
 
                             mMatrixMessageListFragment.sendImage(message);
                         }

--- a/app/src/main/java/org/matrix/matrixandroidsdk/activity/SettingsActivity.java
+++ b/app/src/main/java/org/matrix/matrixandroidsdk/activity/SettingsActivity.java
@@ -22,7 +22,6 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -46,9 +45,6 @@ import org.matrix.matrixandroidsdk.R;
 import org.matrix.matrixandroidsdk.adapters.AdapterUtils;
 import org.matrix.matrixandroidsdk.util.ResourceUtils;
 import org.matrix.matrixandroidsdk.util.UIUtils;
-
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 
 public class SettingsActivity extends MXCActionBarActivity {
 
@@ -224,23 +220,19 @@ public class SettingsActivity extends MXCActionBarActivity {
 
         if (newAvatarUri != null) {
             Log.d(LOG_TAG, "Selected image to upload: " + newAvatarUri);
-            InputStream contentStream = null;
-            String contentMimeType = null;
-            try {
-                contentStream = getContentResolver().openInputStream(newAvatarUri);
-                contentMimeType = getContentResolver().getType(newAvatarUri);
-            } catch (FileNotFoundException e) {
-                Log.e(LOG_TAG, "Failed to open image upload input stream", e);
+            ResourceUtils.Resource resource = ResourceUtils.openResource(this, newAvatarUri);
+            if (resource == null) {
                 Toast.makeText(SettingsActivity.this,
                         getString(R.string.settings_failed_to_upload_avatar),
                         Toast.LENGTH_LONG).show();
                 return;
             }
+
             MXSession session = Matrix.getInstance(this).getDefaultSession();
 
             final ProgressDialog progressDialog = ProgressDialog.show(this, null, getString(R.string.message_uploading), true);
 
-            session.getContentManager().uploadContent(contentStream, contentMimeType, new ContentManager.UploadCallback() {
+            session.getContentManager().uploadContent(resource.contentStream, resource.mimeType, new ContentManager.UploadCallback() {
                 @Override
                 public void onUploadComplete(ContentResponse uploadResponse) {
                     if (uploadResponse == null) {

--- a/app/src/main/java/org/matrix/matrixandroidsdk/util/ResourceUtils.java
+++ b/app/src/main/java/org/matrix/matrixandroidsdk/util/ResourceUtils.java
@@ -16,26 +16,44 @@
 package org.matrix.matrixandroidsdk.util;
 
 import android.app.Activity;
-import android.database.Cursor;
 import android.net.Uri;
-import android.provider.MediaStore;
+import android.util.Log;
+
+import java.io.InputStream;
 
 /**
  * Static resource utility methods.
  */
 public class ResourceUtils {
 
+    private static final String LOG_TAG = "ResourceUtils";
+
+    public static class Resource {
+        public final InputStream contentStream;
+        public final String mimeType;
+
+        public Resource(InputStream contentStream, String mimeType) {
+            this.contentStream = contentStream;
+            this.mimeType = mimeType;
+        }
+    }
+
     /**
-     * Get the file path of an image given its URI returned from onActivityResult.
+     * Get a resource stream and metadata about it given its URI returned from onActivityResult.
+     *
      * @param activity the activity
      * @param uri the URI
-     * @return the file path
+     * @return a {@link Resource} encapsulating the opened resource stream and associated metadata
+     *      or {@code null} if opening the resource stream failed.
      */
-    public static String getImagePath(Activity activity, Uri uri) {
-        String[] projection = { MediaStore.Images.Media.DATA };
-        Cursor cursor = activity.managedQuery(uri, projection, null, null, null);
-        int columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
-        cursor.moveToFirst();
-        return cursor.getString(columnIndex);
+    public static Resource openResource(Activity activity, Uri uri) {
+        try {
+            return new Resource(
+                    activity.getContentResolver().openInputStream(uri),
+                    activity.getContentResolver().getType(uri));
+        } catch (Exception e) {
+            Log.e(LOG_TAG, "Failed to open resource input stream", e);
+            return null;
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="message_changes_successful">Changes successfully made</string>
     <string name="message_unsaved_changes">There are unsaved changes. Leaving will discard them.</string>
     <string name="message_uploading">Uploading&#8230;</string>
+    <string name="message_failed_to_upload">Failed to upload image</string>
 
     <string name="option_attach_image">Attach image</string>
     <string name="option_attach_video">Attach video</string>
@@ -97,4 +98,5 @@
     <string name="settings_config_user_id">User ID: %s</string>
     <string name="settings_config_access_token">Access token: %s</string>
 
+    <string name="settings_failed_to_upload_avatar">Failed to upload avatar</string>
 </resources>

--- a/sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
+++ b/sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
@@ -158,7 +158,7 @@ public class ContentManager {
                 conn.setRequestMethod("POST");
 
                 conn.setRequestProperty("Content-Type", mimeType);
-                // TODO: Add (optional) way to specify Content-Length
+                conn.setRequestProperty("Content-Length", Integer.toString(contentStream.available()));
 
                 conn.connect();
 


### PR DESCRIPTION
When using the G+-Photos app, it seems that photo URIs returned by the pick image intent are no longer associated with a filename. Use the activity's content resolver to get a stream instead and use that for uploading.

I have not tested this with the AOSP Gallery app because my phone (Nexus 4 with factory L image) only has the G+-Photos app. It would be great if somebody with this app could try the patch.

`ContentManager` now no longer sets `Content-Length`. During my testing on matrix.org, this didn't seem to be a problem, but reading the synapse source it actually should (see https://github.com/matrix-org/synapse/blob/771892b3144e5a45739a097f818e71a7ce5d8ce2/synapse/media/v1/upload_resource.py#L48). Not sure what's going on here.