### PR TITLE
Use wrapper types for ImageInfo.{w,h,size} because they are optional

### DIFF
--- a/sdk/src/main/java/org/matrix/androidsdk/rest/model/ImageInfo.java
+++ b/sdk/src/main/java/org/matrix/androidsdk/rest/model/ImageInfo.java
@@ -17,7 +17,7 @@ package org.matrix.androidsdk.rest.model;
 
 public class ImageInfo {
     public String mimetype;
-    public int w;
-    public int h;
-    public long size;
+    public Integer w;
+    public Integer h;
+    public Long size;
 }


### PR DESCRIPTION
This allows them to be null if the values are not present in the json response.