### PR TITLE
Don't bing if no rules match

### DIFF
--- a/sdk/src/main/java/org/matrix/androidsdk/util/BingRulesManager.java
+++ b/sdk/src/main/java/org/matrix/androidsdk/util/BingRulesManager.java
@@ -107,8 +107,8 @@ public class BingRulesManager {
                 }
             }
         }
-        // The default is to bing
-        return true;
+        // The default is not to bing
+        return false;
     }
 
     private boolean eventMatchesConditions(Event event, List<Condition> conditions) {


### PR DESCRIPTION
The default rules in synapse are set up to match and notify when
mentioned in a group chat and always in 1-to-1 conversations. To have
sane defaults, don't notify in all other cases.