### PR TITLE
Basic support for Android Auto

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -124,7 +124,17 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name="org.matrix.matrixandroidsdk.car.CarBroadcastReceiver">
+            <intent-filter>
+                <action android:name="org.matrix.matrixandroidsdk.ACTION_MESSAGE_HEARD" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="org.matrix.matrixandroidsdk.ACTION_MESSAGE_REPLY" />
+            </intent-filter>
+        </receiver>
+
         <service android:name=".gcm.GcmIntentService" />
+
         <service android:name="org.matrix.matrixandroidsdk.services.EventStreamService" />
 
         <provider
@@ -132,6 +142,9 @@
             android:name="org.matrix.matrixandroidsdk.db.ConsoleContentProvider"
             android:exported="true" />
 
+        <meta-data
+          android:name="com.google.android.gms.car.application"
+          android:resource="@xml/automotive_app_desc" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/matrix/matrixandroidsdk/car/CarBroadcastReceiver.java
+++ b/app/src/main/java/org/matrix/matrixandroidsdk/car/CarBroadcastReceiver.java
@@ -1,0 +1,78 @@
+package org.matrix.matrixandroidsdk.car;
+
+import android.app.NotificationManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.RemoteInput;
+import android.util.Log;
+
+import org.matrix.androidsdk.MXSession;
+import org.matrix.androidsdk.data.Room;
+import org.matrix.androidsdk.rest.callback.ApiCallback;
+import org.matrix.androidsdk.rest.model.Event;
+import org.matrix.androidsdk.rest.model.MatrixError;
+import org.matrix.androidsdk.rest.model.Message;
+import org.matrix.matrixandroidsdk.Matrix;
+import org.matrix.matrixandroidsdk.util.NotificationUtils;
+
+public class CarBroadcastReceiver extends BroadcastReceiver {
+    private static final String TAG = CarBroadcastReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(final Context context, final Intent intent) {
+        String roomId = intent.getStringExtra(NotificationUtils.EXTRA_ROOM_ID);
+        if (NotificationUtils.ACTION_MESSAGE_HEARD.equals(intent.getAction())) {
+            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.cancelAll();
+        } else if (NotificationUtils.ACTION_MESSAGE_REPLY.equals(intent.getAction())) {
+            final CharSequence reply = getMessageText(intent);
+
+            final MXSession session = Matrix.getInstance(context).getDefaultSession();
+            final Room room = session.getDataHandler().getRoom(roomId);
+            final Message message = new Message();
+            message.body = reply.toString();
+            message.msgtype = Message.MSGTYPE_TEXT;
+
+            Event event = new Event(message, session.getCredentials().userId, room.getRoomId());
+            session.getDataHandler().storeLiveRoomEvent(event);
+            room.sendEvent(event, new ApiCallback<Void>() {
+                @Override
+                public void onSuccess(final Void info) {
+                    Log.d(TAG, "reply sent!");
+                }
+
+                @Override
+                public void onNetworkError(final Exception e) {
+                    Log.d(TAG, "sending reply failed!", e);
+                }
+
+                @Override
+                public void onMatrixError(final MatrixError e) {
+                    Log.d(TAG, "sending reply failed with matrix error " + e.errcode + " " + e.error);
+                }
+
+                @Override
+                public void onUnexpectedError(final Exception e) {
+                    Log.d(TAG, "sending reply failed!", e);
+                }
+            });
+        }
+    }
+
+    /**
+     * Get the message text from the intent.
+     * Note that you should call
+     * RemoteInput.getResultsFromIntent() to process
+     * the RemoteInput.
+     */
+    private CharSequence getMessageText(Intent intent) {
+        Bundle remoteInput =
+                RemoteInput.getResultsFromIntent(intent);
+        if (remoteInput != null) {
+            return remoteInput.getCharSequence(NotificationUtils.CAR_VOICE_REPLY_KEY);
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/org/matrix/matrixandroidsdk/gcm/GcmIntentService.java
+++ b/app/src/main/java/org/matrix/matrixandroidsdk/gcm/GcmIntentService.java
@@ -57,6 +57,6 @@ public class GcmIntentService extends IntentService {
         Notification n = NotificationUtils.buildMessageNotification(this, from, body, roomId, roomName, true);
         NotificationManager nm =(NotificationManager) GcmIntentService.this
                 .getSystemService(Context.NOTIFICATION_SERVICE);
-        nm.notify(MSG_NOTIFICATION_ID, n);
+        nm.notify(roomId, MSG_NOTIFICATION_ID, n);
     }
 }

--- a/app/src/main/java/org/matrix/matrixandroidsdk/services/EventStreamService.java
+++ b/app/src/main/java/org/matrix/matrixandroidsdk/services/EventStreamService.java
@@ -31,6 +31,7 @@ import org.matrix.androidsdk.data.RoomState;
 import org.matrix.androidsdk.listeners.MXEventListener;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.RoomMember;
+import org.matrix.androidsdk.rest.model.User;
 import org.matrix.androidsdk.rest.model.bingrules.BingRule;
 import org.matrix.matrixandroidsdk.Matrix;
 import org.matrix.matrixandroidsdk.R;
@@ -44,7 +45,8 @@ import org.matrix.matrixandroidsdk.util.NotificationUtils;
  * A foreground service in charge of controlling whether the event stream is running or not.
  */
 public class EventStreamService extends Service {
-    public static enum StreamAction {
+
+    public enum StreamAction {
         UNKNOWN,
         STOP,
         START,
@@ -92,6 +94,17 @@ public class EventStreamService extends Service {
     }
 
     private MXEventListener mListener = new MXEventListener() {
+
+        @Override
+        public void onLiveEvent(final Event event, final RoomState roomState) {
+            super.onLiveEvent(event, roomState);
+            Log.i(LOG_TAG, "onLiveEvent >>>> " + event);
+        }
+
+        @Override
+        public void onPresenceUpdate(final Event event, final User user) {
+            Log.i(LOG_TAG, "onPresenceUpdate >>>> " + event);
+        }
 
         @Override
         public void onBingEvent(Event event, RoomState roomState, BingRule bingRule) {
@@ -148,7 +161,7 @@ public class EventStreamService extends Service {
             NotificationManager nm = (NotificationManager) EventStreamService.this.getSystemService(Context.NOTIFICATION_SERVICE);
             nm.cancelAll();
 
-            nm.notify(MSG_NOTIFICATION_ID, n);
+            nm.notify(event.roomId, MSG_NOTIFICATION_ID, n);
         }
 
         @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,7 +162,7 @@
 
     <!-- contacts list screen -->
     <string name="contacts">Contacts</string>
-    <string name="invite_this_user_to_use_matrix">Invite this user user to use matrix with</string>
+    <string name="invite_this_user_to_use_matrix">Invite this user to use matrix with</string>
     <string name="invitation_message">I\'d like to chat with you with matrix. Please, visit the website http://matrix.org to have more information.</string>
 
     <!-- Settings screen -->
@@ -202,5 +202,6 @@
     <string name="settings_key_display_public_rooms_recents">settings_key_display_public_rooms_recents</string>
 
     <string name="logo">Logo</string>
+    <string name="user_says_body">%1$s says %2$s</string>
 
 </resources>

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,3 @@
+<automotiveApp>
+  <uses name="notification" />
+</automotiveApp>


### PR DESCRIPTION
This PR adds support for Android Auto.

Notifcations that are created by the EventStreamService or GCM messages are extended for in-car use. 
The user can send a reply directly from the car UI.

To test this you need to use a car with Android Auto or install the Message Simulator (available with the SDK manager) on your device.

Remark: for in-car use (as well as for Android Wear) notifications should also be able to somehow handle/show the history in the room if several new messages arrive. Currently, there is only one notification for all rooms and all messages.