### PR TITLE
Warning message when encrypted content is received (Fix #455)

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/adapters/MessagesAdapter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/adapters/MessagesAdapter.java
@@ -739,7 +739,7 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
     }
 
     /**
-     * Event to view type.
+     * Convert Event to view type.
      * @param event the event to convert
      * @return the view type.
      */
@@ -776,6 +776,8 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
                 // Default is to display the body as text
                 viewType = ROW_TYPE_TEXT;
             }
+        } else if (Event.EVENT_TYPE_MESSAGE_ENCRYPTED.equals(event.type)) {
+            viewType = ROW_TYPE_TEXT;
         }
         else if (
                 event.isCallEvent() ||
@@ -786,8 +788,8 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
                         Event.EVENT_TYPE_STATE_ROOM_THIRD_PARTY_INVITE.equals(event.type)
                 ) {
             viewType = ROW_TYPE_NOTICE;
-        }
-        else {
+
+        } else {
             throw new RuntimeException("Unknown event type: " + event.type);
         }
 
@@ -1602,7 +1604,7 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
             body.setSpan(new ForegroundColorSpan(mHighlightMessageTextColor), 0, body.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
-        highlightPattern(bodyTextView, body, TextUtils.equals("org.matrix.custom.html", message.format) ? getSanitisedHtml(message.formatted_body) : null, mPattern);
+        highlightPattern(bodyTextView, body, TextUtils.equals(Message.FORMAT_MATRIX_HTML, message.format) ? getSanitisedHtml(message.formatted_body) : null, mPattern);
 
         int textColor;
 
@@ -2335,8 +2337,7 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
             // A message is displayable as long as it has a body
             Message message = JsonUtils.toMessage(event.content);
             return (message.body != null) && (!message.body.equals(""));
-        }
-        else if (Event.EVENT_TYPE_STATE_ROOM_TOPIC.equals(event.type)
+        } else if (Event.EVENT_TYPE_STATE_ROOM_TOPIC.equals(event.type)
                 || Event.EVENT_TYPE_STATE_ROOM_NAME.equals(event.type)) {
             EventDisplay display = new EventDisplay(mContext, event, roomState);
             return display.getTextualDisplay() != null;
@@ -2351,6 +2352,8 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
             EventDisplay display = new EventDisplay(mContext, event, roomState);
             return display.getTextualDisplay() != null;
         } else if (Event.EVENT_TYPE_STATE_HISTORY_VISIBILITY.equals(event.type)) {
+            return true;
+        } else if (Event.EVENT_TYPE_MESSAGE_ENCRYPTED.equals(event.type)) {
             return true;
         }
         return false;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomSummary.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomSummary.java
@@ -117,6 +117,7 @@ public class RoomSummary implements java.io.Serializable {
             }
         } else if (!TextUtils.isEmpty(type)){
             isSupported = TextUtils.equals(Event.EVENT_TYPE_STATE_ROOM_TOPIC, type) ||
+                    TextUtils.equals(Event.EVENT_TYPE_MESSAGE_ENCRYPTED, type) ||
                     TextUtils.equals(Event.EVENT_TYPE_STATE_ROOM_NAME, type) ||
                     TextUtils.equals(Event.EVENT_TYPE_STATE_ROOM_MEMBER, type) ||
                     TextUtils.equals(Event.EVENT_TYPE_STATE_ROOM_CREATE, type) ||

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -797,6 +797,7 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
 
         return mDisplayAllEvents ||
                 Event.EVENT_TYPE_MESSAGE.equals(type)          ||
+                Event.EVENT_TYPE_MESSAGE_ENCRYPTED.equals(type)||
                 Event.EVENT_TYPE_STATE_ROOM_NAME.equals(type)  ||
                 Event.EVENT_TYPE_STATE_ROOM_TOPIC.equals(type) ||
                 Event.EVENT_TYPE_STATE_ROOM_MEMBER.equals(type) ||
@@ -1986,7 +1987,7 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
     }
 
     //==============================================================================================================
-    // MatrixMessagesFrament methods
+    // MatrixMessagesFragment methods
     //==============================================================================================================
 
     @Override

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -58,6 +58,7 @@ public class Event implements java.io.Serializable {
 
     public static final String EVENT_TYPE_PRESENCE = "m.presence";
     public static final String EVENT_TYPE_MESSAGE = "m.room.message";
+    public static final String EVENT_TYPE_MESSAGE_ENCRYPTED = "m.room.encrypted";
     public static final String EVENT_TYPE_FEEDBACK = "m.room.message.feedback";
     public static final String EVENT_TYPE_TYPING = "m.typing";
     public static final String EVENT_TYPE_REDACTION = "m.room.redaction";

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Message.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Message.java
@@ -24,6 +24,7 @@ public class Message {
     public static final String MSGTYPE_VIDEO = "m.video";
     public static final String MSGTYPE_LOCATION = "m.location";
     public static final String MSGTYPE_FILE = "m.file";
+    public static final String FORMAT_MATRIX_HTML = "org.matrix.custom.html";
 
     public String msgtype;
     public String body;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/EventDisplay.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/EventDisplay.java
@@ -16,8 +16,10 @@
 package org.matrix.androidsdk.util;
 
 import android.content.Context;
+import android.graphics.Typeface;
 import android.text.Html;
 import android.text.Spannable;
+import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
@@ -49,6 +51,8 @@ public class EventDisplay {
     private final Context mContext;
     private final RoomState mRoomState;
     private boolean mPrependAuthor;
+
+    public static final CharSequence DEFAULT_MESSAGE_ENCRYPTED_NOT_YET_SUPPORTED = "Encrypted message";
 
     // let the application defines if the redacted events must be displayed
     public static boolean mDisplayRedactedEvents = false;
@@ -159,7 +163,7 @@ public class EventDisplay {
                 // check for html formatting
                 if (jsonEventContent.has("formatted_body") && jsonEventContent.has("format")) {
                     String format = jsonEventContent.getAsJsonPrimitive("format").getAsString();
-                    if ("org.matrix.custom.html".equals(format)) {
+                    if (Message.FORMAT_MATRIX_HTML.equals(format)) {
                         String htmlBody = jsonEventContent.getAsJsonPrimitive("formatted_body").getAsString();
 
                         // some markers are not supported so fallback on an ascii display until to find the right way to manage them
@@ -185,6 +189,11 @@ public class EventDisplay {
                         ((SpannableStringBuilder)text).setSpan(new StyleSpan(android.graphics.Typeface.BOLD), 0, userDisplayName.length()+1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
                     }
                 }
+            } else if (Event.EVENT_TYPE_MESSAGE_ENCRYPTED.equals(mEvent.type)) {
+                // TODO to be removed - temporary patch (wait for e2e encryption final version)
+                SpannableString spannableStr = new SpannableString(DEFAULT_MESSAGE_ENCRYPTED_NOT_YET_SUPPORTED);
+                spannableStr.setSpan(new android.text.style.StyleSpan(Typeface.ITALIC), 0, DEFAULT_MESSAGE_ENCRYPTED_NOT_YET_SUPPORTED.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                text = spannableStr;
             } else if (Event.EVENT_TYPE_STATE_ROOM_TOPIC.equals(mEvent.type)) {
                 String topic = jsonEventContent.getAsJsonPrimitive("topic").getAsString();
 


### PR DESCRIPTION
Add specific message ("Encrypted message") when an encrypted message (m.room.encrypted) is received.
Should fix [#455](https://github.com/vector-im/vector-android/issues/455)