### PR TITLE
fix_invalid_messages_indexes

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/adapters/MessagesAdapter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/adapters/MessagesAdapter.java
@@ -227,6 +227,11 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
          * @param messageId the message id.
          */
         void onMessageIdClick(String messageId);
+
+        /**
+         * The required indexes are not anymore valid.
+         */
+        void onInvalidIndexes();
     }
 
     protected static final int ROW_TYPE_TEXT = 0;
@@ -813,6 +818,22 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
+        // GA Crash : it seems that some invalid indexes are required
+        if (position >= getCount()) {
+            Log.e(LOG_TAG, "## getView() : invalid index " + position + " >= " + getCount());
+
+            // create dummy one is required
+            if (null == convertView) {
+                convertView = mLayoutInflater.inflate(mRowTypeToLayoutId.get(ROW_TYPE_TEXT), parent, false);
+            }
+
+            if (null != mMessagesAdapterEventsListener) {
+                mMessagesAdapterEventsListener.onInvalidIndexes();
+            }
+
+            return convertView;
+        }
+
         switch (getItemViewType(position)) {
             case ROW_TYPE_TEXT:
                 return getTextView(position, convertView, parent);
@@ -1576,11 +1597,6 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
     private View getTextView(final int position, View convertView, ViewGroup parent) {
         if (convertView == null) {
             convertView = mLayoutInflater.inflate(mRowTypeToLayoutId.get(ROW_TYPE_TEXT), parent, false);
-        }
-
-        // GA Crash
-        if (position >= getCount()) {
-            return convertView;
         }
 
         MessageRow row = getItem(position);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -2329,6 +2329,34 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
     public void onMessageIdClick(String messageId) {
     }
 
+    private int mInvalidIndexesCount = 0;
+
+    @Override
+    public void onInvalidIndexes() {
+        mInvalidIndexesCount++;
+
+        // it should happen once
+        // else we assume that the adapter is really corrupted
+        // It seems better to close the linked activity to avoid infinite refresh.
+        if (1 == mInvalidIndexesCount) {
+            mMessageListView.post(new Runnable() {
+                @Override
+                public void run() {
+                    mAdapter.notifyDataSetChanged();
+                }
+            });
+        } else {
+            mMessageListView.post(new Runnable() {
+                @Override
+                public void run() {
+                    if (null != getActivity()) {
+                        getActivity().finish();
+                    }
+                }
+            });
+        }
+    }
+
     //==============================================================================================================
     // search methods
     //==============================================================================================================


### PR DESCRIPTION
In some cases, the getView index is out ouf bound.
BY default, it used to provide the latest recycled one whereas it should warn the parent fragment that something went wrong.