### PR TITLE
Fix Implementing remaining 1:1 semantics across the UI #618

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -1176,7 +1176,7 @@ public class MXSession {
     }
 
     /**
-     * Return the list of the direct chat rooms for the user given in parameter.<br>
+     * Return the list of the direct chat room IDs for the user given in parameter.<br>
      * Based on the account_data map content, the entry associated with aSearchedUserId is returned.
      * @param aSearchedUserId user ID
      * @return the list of the direct chat room Id
@@ -1184,12 +1184,20 @@ public class MXSession {
     public List<String> getDirectChatRoomIdsList(String aSearchedUserId) {
         ArrayList<String> directChatRoomIdsList = new ArrayList<>();
         IMXStore store = getDataHandler().getStore();
+        Room room;
 
         HashMap<String, List<String>> params;
 
         if(null != (params = new HashMap<>(store.getDirectChatRoomsDict()))){
             if (params.containsKey(aSearchedUserId)) {
-                directChatRoomIdsList = new ArrayList<>(params.get(aSearchedUserId));
+                directChatRoomIdsList = new ArrayList<>();
+
+                for(String roomId: params.get(aSearchedUserId)) {
+                    room = store.getRoom(roomId);
+                    if(null != room) { // skipp empty rooms
+                        directChatRoomIdsList.add(roomId);
+                    }
+                }
             } else {
                 Log.w(LOG_TAG,"## getDirectChatRoomIdsList(): UserId "+aSearchedUserId+" has no entry in account_data");
             }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -1176,6 +1176,31 @@ public class MXSession {
     }
 
     /**
+     * Return the list of the direct chat rooms for the user given in parameter.<br>
+     * Based on the account_data map content, the entry associated with aSearchedUserId is returned.
+     * @param aSearchedUserId user ID
+     * @return the list of the direct chat room Id
+     */
+    public List<String> getDirectChatRoomIdsList(String aSearchedUserId) {
+        ArrayList<String> directChatRoomIdsList = new ArrayList<>();
+        IMXStore store = getDataHandler().getStore();
+
+        HashMap<String, List<String>> params;
+
+        if(null != (params = new HashMap<>(store.getDirectChatRoomsDict()))){
+            if (params.containsKey(aSearchedUserId)) {
+                directChatRoomIdsList = new ArrayList<>(params.get(aSearchedUserId));
+            } else {
+                Log.w(LOG_TAG,"## getDirectChatRoomIdsList(): UserId "+aSearchedUserId+" has no entry in account_data");
+            }
+        } else {
+            Log.e(LOG_TAG,"## getDirectChatRoomIdsList(): failure - getDirectChatRoomsDict()=null");
+        }
+
+        return directChatRoomIdsList;
+    }
+
+    /**
      * Toggles the direct chat status of a room.<br>
      * Create a new direct chat room in the account data section if the room does not exist,
      * otherwise the room is removed from the account data section.


### PR DESCRIPTION
- update toogleDirectChatRoom() to change the criterias to identify the direct chat user ID target (1/oldest joined members 2/oldest invited memenbers 3/the current user himself)