### PR TITLE
prevent crash on kitkat in GZIPOutputStream

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/MXFileStore.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/MXFileStore.java
@@ -1222,7 +1222,12 @@ public class MXFileStore extends MXMemoryStore {
             if (null != room) {
                 long start1 = System.currentTimeMillis();
                 FileOutputStream fos = new FileOutputStream(roomStateFile);
-                GZIPOutputStream gz = new GZIPOutputStream(fos);
+                GZIPOutputStream gz = null;
+                if (android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.KITKAT) {
+                    gz = new GZIPOutputStream(fos, false);
+                } else {
+                    gz = new GZIPOutputStream(fos);
+                }
                 ObjectOutputStream out = new ObjectOutputStream(gz);
 
                 out.writeObject(room.getState());


### PR DESCRIPTION
There was fantom crash on kitkat devices

Fatal Exception: java.lang.IllegalStateException: attempt to use Deflater after calling end
       at java.util.zip.Deflater.checkOpen(Deflater.java:476)
       at java.util.zip.Deflater.deflateImpl(Deflater.java:236)
       at java.util.zip.Deflater.deflate(Deflater.java:232)
       at java.util.zip.DeflaterOutputStream.flush(DeflaterOutputStream.java:193)
       at java.io.FilterOutputStream.flush(FilterOutputStream.java:88)
       at java.io.DataOutputStream.flush(DataOutputStream.java:63)
       at java.io.ObjectOutputStream.flush(ObjectOutputStream.java:462)
       at java.io.ObjectOutputStream.close(ObjectOutputStream.java:337)
       at org.matrix.androidsdk.data.MXFileStore.saveRoomState(SourceFile:1032)