### PR TITLE
fix_quick_reply_without_echo

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/adapters/MessagesAdapter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/adapters/MessagesAdapter.java
@@ -704,7 +704,11 @@ public abstract class MessagesAdapter extends ArrayAdapter<MessageRow> {
 
             if ((!mIsSearchMode) && refresh) {
                 this.notifyDataSetChanged();
+            } else {
+                setNotifyOnChange(true);
             }
+        } else {
+            setNotifyOnChange(true);
         }
     }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -2325,6 +2325,18 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
     }
 
     @Override
+    public void onSentEvent(Event event) {
+        // detect if a message was sent but not yet added to the adapter
+        // For example, the quick reply does not use the fragement to send messages
+        // Thus, the messages are not added to the adapater.
+        // onEvent is not called because the server event echo manages an event sent by itself
+        if ((null == mAdapter.getMessageRow(event.eventId)) && canAddEvent(event)) {
+            // refresh the listView only when it is a live timeline or a search
+            mAdapter.add(new MessageRow(event, mRoom.getLiveState()), true);
+        }
+    }
+
+    @Override
     public void onLiveEventsChunkProcessed() {
         // NOP
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessagesFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessagesFragment.java
@@ -89,6 +89,8 @@ public class MatrixMessagesFragment extends Fragment {
     public interface MatrixMessagesListener {
         void onEvent(Event event, EventTimeline.Direction direction, RoomState roomState);
 
+        void onSentEvent(Event event);
+
         void onLiveEventsChunkProcessed();
 
         void onReceiptEvent(List<String> senderIds);
@@ -144,6 +146,13 @@ public class MatrixMessagesFragment extends Fragment {
                     // fill the screen
                     requestInitialHistory();
                 }
+            }
+        }
+
+        @Override
+        public void onSentEvent(Event event) {
+            if (null != mMatrixMessagesListener) {
+                mMatrixMessagesListener.onSentEvent(event);
             }
         }
     };


### PR DESCRIPTION
fix https://github.com/vector-im/riot-android/issues/1080 The message sent with QuickReply is not added to the room history if the dedicated room activity is opened