### PR TITLE
Let matrix sdk be used through Maven

### DIFF
--- a/matrix-sdk/build.gradle
+++ b/matrix-sdk/build.gradle
@@ -100,7 +100,7 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     compile 'io.pristine:libjingle:9690@aar'
 
-    compile(name: 'olm-sdk', ext: 'aar')
+    compile 'org.matrix:olm-sdk:olm-sdk@aar'
 
     // Robolectric
     testCompile 'com.android.support.test:runner:0.3'

--- a/matrix-sdk/src/main/AndroidManifest.xml
+++ b/matrix-sdk/src/main/AndroidManifest.xml
@@ -13,9 +13,4 @@
     <!-- libjingle is designed for API >= 15 but the app should work from API >= 11 -->
     <uses-sdk tools:overrideLibrary="io.pristine.libjingle"/>
 
-    <application
-        tools:replace="label"
-        android:label="@string/matrix_sdk_app_name">
-    </application>
-
 </manifest>


### PR DESCRIPTION
This PR fix the generated pom.xml when releasing the library using maven, enable the use of Jitpack or any Maven repository.