### PR TITLE
set_presence=off as well when app is in background

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/sync/EventsThread.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/sync/EventsThread.java
@@ -496,7 +496,9 @@ public class EventsThread extends Thread {
                 final int fServerTimeout = serverTimeout;
                 mNextServerTimeoutms = mDefaultServerTimeoutms;
 
-                mEventsRestClient.syncFromToken(mCurrentToken, serverTimeout, DEFAULT_CLIENT_TIMEOUT_MS, (mIsCatchingUp && mIsOnline) ? "offline" : null, inlineFilter, new SimpleApiCallback<SyncResponse>(mFailureCallback) {
+                mEventsRestClient.syncFromToken(mCurrentToken, serverTimeout, DEFAULT_CLIENT_TIMEOUT_MS,
+                        (mIsOnline && !mIsCatchingUp) ? null : "offline", inlineFilter,
+                        new SimpleApiCallback<SyncResponse>(mFailureCallback) {
                     @Override
                     public void onSuccess(SyncResponse syncResponse) {
                         if (!mKilling) {


### PR DESCRIPTION
this is meant to fix vector-im/riot-android#1509

Signed-off-by: Matthias Kesler <krombel@krombel.de>