### PR TITLE
avoid_fetch_one_time_key_count

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Sync/DeviceOneTimeKeysCountSyncResponse.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Sync/DeviceOneTimeKeysCountSyncResponse.java
@@ -1,0 +1,22 @@
+/* 
+ * Copyright 2016 OpenMarket Ltd
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk.rest.model.Sync;
+
+public class DeviceOneTimeKeysCountSyncResponse implements java.io.Serializable {
+
+    public Integer signed_curve25519;
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Sync/SyncResponse.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Sync/SyncResponse.java
@@ -53,4 +53,9 @@ public class SyncResponse implements java.io.Serializable {
      * Devices list update
      */
     public DeviceListResponse deviceLists;
+
+    /**
+     * One time keys management
+     */
+    public DeviceOneTimeKeysCountSyncResponse deviceOneTimeKeysCount;
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/crypto/KeysUploadResponse.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/crypto/KeysUploadResponse.java
@@ -48,5 +48,15 @@ public class KeysUploadResponse {
 
         return res;
     }
+
+    /**
+     * Tells if there is a oneTimeKeys for a dedicated algorithm.
+     *
+     * @param algorithm the algorithm
+     * @return true if it is found
+     */
+    public boolean hasOneTimeKeyCountsForAlgorithm(String algorithm) {
+        return (null != oneTimeKeyCounts) && (null != algorithm) && oneTimeKeyCounts.containsKey(algorithm);
+    }
 }
 


### PR DESCRIPTION
report code update from https://github.com/matrix-org/matrix-js-sdk/pull/493
use device_one_time_keys_count transmitted by /sync