### PR TITLE
Make state event redaction handling gentler with homeserver

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/EventTimeline.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/EventTimeline.java
@@ -1584,7 +1584,7 @@ public class EventTimeline {
     private void checkStateEventRedaction(final Event redactionEvent) {
 
         final String eventId = redactionEvent.getRedacts();
-        Log.d(LOG_TAG, "checkStateEventRedaction from event " + eventId);
+        Log.d(LOG_TAG, "checkStateEventRedaction of event " + eventId);
 
         // check if the state events is locally known
         mState.getStateEvents(getStore(), null, new SimpleApiCallback<List<Event>>() {
@@ -1598,12 +1598,12 @@ public class EventTimeline {
 
                     if (TextUtils.equals(stateEvent.eventId, eventId)) {
 
+                        Log.d(LOG_TAG, "checkStateEventRedaction: the current room state has been modified by the event redaction");
+
                         // remove expected keys
                         stateEvent.prune(redactionEvent);
 
                         stateEvents.set(index, stateEvent);
-
-                        Log.d(LOG_TAG, "checkStateEventRedaction: the current room state has been modified by the event redaction");
 
                         // digest the updated state
                         processStateEvent(stateEvent, Direction.FORWARDS);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/EventTimeline.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/EventTimeline.java
@@ -312,34 +312,6 @@ public class EventTimeline {
     }
 
     /**
-     * Init the history with a list of stateEvents
-     *
-     * @param stateEvents the state events
-     */
-    private void initHistory(List<Event> stateEvents) {
-        // clear the states
-        mState = new RoomState();
-        mState.roomId = mRoomId;
-        mState.setDataHandler(mDataHandler);
-
-        if (null != stateEvents) {
-            for (Event event : stateEvents) {
-                try {
-                    processStateEvent(event, Direction.FORWARDS);
-                } catch (Exception e) {
-                    Log.e(LOG_TAG, "initHistory failed " + e.getMessage());
-                }
-            }
-        }
-
-        mStore.storeLiveStateForRoom(mRoomId);
-        initHistory();
-
-        // warn that there was a flush
-        mDataHandler.onRoomFlush(mRoomId);
-    }
-
-    /**
      * @return The state of the room at the top most recent event of the timeline.
      */
     public RoomState getState() {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomState.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomState.java
@@ -423,6 +423,27 @@ public class RoomState implements Externalizable {
     }
 
     /**
+     * Retrieve a room member from its original event id.
+     *
+     * @param eventId the event id.
+     * @return the linked member it exists.
+     */
+    public RoomMember getMemberByEventId(String eventId) {
+        RoomMember member = null;
+
+        synchronized (this) {
+            for (RoomMember aMember : mMembers.values()) {
+                if (aMember.getOriginalEventId().equals(eventId)) {
+                    member = aMember;
+                    break;
+                }
+            }
+        }
+
+        return member;
+    }
+
+    /**
      * Remove a member defines by its user id.
      *
      * @param userId the user id.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/RoomMember.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/RoomMember.java
@@ -311,6 +311,19 @@ public class RoomMember implements Externalizable {
         return null;
     }
 
+    /**
+     * Prune the room member data as we would have done with the original state event.
+     */
+    public void prune() {
+        // Redact redactable data
+        displayname = null;
+        avatarUrl = null;
+        reason = null;
+
+        // Note: if we had access to the original event content, we should store
+        // the `redacted_because` of the redaction event in it.
+    }
+
     public RoomMember deepCopy() {
         RoomMember copy = new RoomMember();
         copy.displayname = displayname;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/RoomMember.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/RoomMember.java
@@ -312,7 +312,7 @@ public class RoomMember implements Externalizable {
     }
 
     /**
-     * Prune the room member data as we would have done with the original state event.
+     * Prune the room member data as we would have done with its original state event.
      */
     public void prune() {
         // Redact redactable data


### PR DESCRIPTION
https://github.com/vector-im/riot-android/issues/2117

- Reenable the previous optimisation to resolve state redaction locally
- Fix it to manage new storage of room members
- Fix it to locally redact current state events which the message is no more in the local store
- Fix it to avoid that the corresponding room disappears from the app
- Disable the use of room initial sync