### PR TITLE
Send Access-Token as header instead of query param

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
@@ -143,7 +143,7 @@ public class RestClient<T> {
 
                         // Add the access token to all requests if it is set
                         if ((mCredentials != null) && (mCredentials.accessToken != null)) {
-                            request.addEncodedQueryParam(PARAM_ACCESS_TOKEN, mCredentials.accessToken);
+                            request.addHeader("Authorization", "Bearer " + mCredentials.accessToken);
                         }
                     }
                 });


### PR DESCRIPTION
To do not have the access token in the query param (and accidentally have that in the logs when logging the query) and make use of header compression (on http2) this PR proposes that shift.

Synapse supports that for quite a while now (matrix-org/synapse#2285)

Signed-Off-by: Matthias Kesler <krombel@krombel.de>