### PR TITLE
Bug Fix: E2E: App keeps displaying ignored keyshare requests

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/IncomingRoomKeyRequest.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/IncomingRoomKeyRequest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 OpenMarket Ltd
+ * Copyright 2018 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/IncomingRoomKeyRequest.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/IncomingRoomKeyRequest.java
@@ -54,6 +54,11 @@ public class IncomingRoomKeyRequest implements Serializable {
     public transient Runnable mShare;
 
     /**
+     * The runnable to call to ignore the key share request.
+     */
+    public transient Runnable mIgnore;
+
+    /**
      * Constructor
      *
      * @param event the event

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2016 OpenMarket Ltd
  * Copyright 2017 Vector Creations Ltd
+ * Copyright 2018 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
@@ -1699,6 +1699,18 @@ public class MXCrypto {
                     }
                 };
 
+                request.mIgnore = new Runnable() {
+                    @Override
+                    public void run() {
+                        getEncryptingThreadHandler().post(new Runnable() {
+                            @Override
+                            public void run() {
+                                mCryptoStore.deleteIncomingRoomKeyRequest(request);
+                            }
+                        });
+                    }
+                };
+
                 // if the device is is verified already, share the keys
                 MXDeviceInfo device = mCryptoStore.getUserDevice(deviceId, userId);
 


### PR DESCRIPTION
https://github.com/vector-im/riot-android/issues/2191

Add a mechanism to remove incoming keyshare requests from the crypto store