### PR TITLE
Add support for M_CONSENT_NOT_GIVEN Matrix error

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -1023,7 +1023,7 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
 
                 @Override
                 public void onMatrixError(final MatrixError e) {
-                    // do not display toast if the sending failed because of unknown deviced (e2e issue)
+                    // do not display toast if the sending failed because of unknown device (e2e issue)
                     if (event.mSentState == Event.SentState.FAILED_UNKNOWN_DEVICES) {
                         getUiHandler().post(new Runnable() {
                             @Override

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -124,6 +124,14 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
          * @param error the crypto error
          */
         void onUnknownDevices(Event event, MXCryptoError error);
+
+        /**
+         * An event sending failed because of consent not given
+         *
+         * @param event       the event
+         * @param matrixError the MatrixError (contains message text and URL)
+         */
+        void onConsentNotGiven(Event event, MatrixError matrixError);
     }
 
     // scroll listener
@@ -966,6 +974,22 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
     }
 
     /**
+     * Warns that a message sending failed because user content has not been given.
+     *
+     * @param event       the event
+     * @param matrixError the MatrixError
+     */
+    private void onConsentNotGiven(Event event, MatrixError matrixError) {
+        if (null != mEventSendingListener) {
+            try {
+                mEventSendingListener.onConsentNotGiven(event, matrixError);
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "onConsentNotGiven failed " + e.getMessage());
+            }
+        }
+    }
+
+    /**
      * Add a media item in the room.
      */
     private void add(final RoomMediaMessage roomMediaMessage) {
@@ -1030,6 +1054,14 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
                             public void run() {
                                 mAdapter.notifyDataSetChanged();
                                 onUnknownDevices(event, (MXCryptoError) e);
+                            }
+                        });
+                    } else if (MatrixError.M_CONSENT_NOT_GIVEN.equals(e.errcode)) {
+                        getUiHandler().post(new Runnable() {
+                            @Override
+                            public void run() {
+                                mAdapter.notifyDataSetChanged();
+                                onConsentNotGiven(event, e);
                             }
                         });
                     } else {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -974,7 +974,7 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
     }
 
     /**
-     * Warns that a message sending failed because user content has not been given.
+     * Warns that a message sending failed because user consent has not been given.
      *
      * @param event       the event
      * @param matrixError the MatrixError

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/MatrixError.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/MatrixError.java
@@ -17,6 +17,8 @@ package org.matrix.androidsdk.rest.model;
 
 import android.text.TextUtils;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -50,6 +52,8 @@ public class MatrixError implements java.io.Serializable {
     public static final String SERVER_NOT_TRUSTED = "M_SERVER_NOT_TRUSTED";
     public static final String TOO_LARGE = "M_TOO_LARGE";
 
+    public static final String M_CONSENT_NOT_GIVEN = "M_CONSENT_NOT_GIVEN";
+
     // custom ones
     public static final String NOT_SUPPORTED = "M_NOT_SUPPORTED";
 
@@ -62,6 +66,9 @@ public class MatrixError implements java.io.Serializable {
     public String errcode;
     public String error;
     public Integer retry_after_ms;
+
+    @SerializedName("consent_uri")
+    public String consentUri;
 
     // extracted from the error response
     public Integer mStatus;


### PR DESCRIPTION
This error is now managed when sending a message

Related to https://github.com/vector-im/riot-android/issues/2287