### PR TITLE
Fix regression on URL preview, along with regression on searching user. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changes to Matrix Android SDK in 0.9.5 (2018-XX-XX)
 =======================================================
 
+Bugfix
+ - Fix regression on URL preview, along with regression on searching user. (vector-im/riot-android#2264)
 
 
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/EventsApi.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/EventsApi.java
@@ -29,7 +29,6 @@ import org.matrix.androidsdk.rest.model.sync.SyncResponse;
 import java.util.Map;
 
 import retrofit2.Call;
-import retrofit2.Callback;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
@@ -78,7 +77,7 @@ public interface EventsApi {
      *
      * @param searchUsersParams the search params.
      */
-    @POST(RestClient.URI_API_PREFIX_PATH_R0 + "/user_directory/search")
+    @POST(RestClient.URI_API_PREFIX_PATH_R0 + "user_directory/search")
     Call<SearchUsersRequestResponse> searchUsers(@Body SearchUsersParams searchUsersParams);
 
     /**
@@ -87,6 +86,6 @@ public interface EventsApi {
      * @param url      the URL
      * @param ts       the ts
      */
-    @GET(RestClient.URI_API_PREFIX_PATH_MEDIA_R0 + "/preview_url")
+    @GET(RestClient.URI_API_PREFIX_PATH_MEDIA_R0 + "preview_url")
     Call<Map<String, Object>> getURLPreview(@Query("url") String url, @Query("ts") long ts);
 }


### PR DESCRIPTION
Fix regression on URL preview, along with regression on searching user. (vector-im/riot-android#2264)

Due to migration to Retrofit 2