### PR TITLE
Support the potential anti-virus scanner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changes to Matrix Android SDK in 0.9.6 (2018-XX-XX)
 =======================================================
 
 Features:
- -
+ - ContentManager: support a potential anti-virus scanner (PR #283).
 
 Improvements:
  - MXCrypto: Add reRequestRoomKeyForEvent to re-request encryption keys to decrypt an event (vector-im/riot-android#2319).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ API Change:
 Translations:
  -
 
+Others:
+ - Media cache is flushed because of the new format of ids.
+
 Build:
  - Add script to check code quality
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
@@ -70,7 +70,11 @@ public class HomeServerConnectionConfig {
      * @param pin                 If true only allow certs matching given fingerprints, otherwise fallback to
      *                            standard X509 checks.
      */
-    public HomeServerConnectionConfig(Uri hsUri, @Nullable Uri identityServerUri, @Nullable Credentials credentials, List<Fingerprint> allowedFingerprints, boolean pin) {
+    public HomeServerConnectionConfig(Uri hsUri,
+                                      @Nullable Uri identityServerUri,
+                                      @Nullable Credentials credentials,
+                                      List<Fingerprint> allowedFingerprints,
+                                      boolean pin) {
         if (hsUri == null || (!"http".equals(hsUri.getScheme()) && !"https".equals(hsUri.getScheme()))) {
             throw new RuntimeException("Invalid home server URI: " + hsUri);
         }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
@@ -56,7 +56,7 @@ public class HomeServerConnectionConfig {
 
     /**
      * @param hsUri       The URI to use to connect to the homeserver
-     * @param credentials The credentials to use, if needed.
+     * @param credentials The credentials to use, if needed. Can be null.
      */
     public HomeServerConnectionConfig(Uri hsUri, @Nullable Credentials credentials) {
         this(hsUri, null, credentials, new ArrayList<Fingerprint>(), false);
@@ -140,7 +140,11 @@ public class HomeServerConnectionConfig {
      * @return the identity server uri
      */
     public Uri getIdentityServerUri() {
-        return (null == mIdentityServerUri) ? mHsUri : mIdentityServerUri;
+        if (null != mIdentityServerUri) {
+            return mIdentityServerUri;
+        }
+        // Else consider the HS uri by default.
+        return mHsUri;
     }
 
     /**
@@ -156,8 +160,11 @@ public class HomeServerConnectionConfig {
      * @return the anti-virus server uri
      */
     public Uri getAntiVirusServerUri() {
-        // Consider the HS uri by default.
-        return (null == mAntiVirusServerUri) ? mHsUri : mAntiVirusServerUri;
+        if (null != mAntiVirusServerUri) {
+            return mAntiVirusServerUri;
+        }
+        // Else consider the HS uri by default.
+        return mHsUri;
     }
 
     /**
@@ -214,7 +221,9 @@ public class HomeServerConnectionConfig {
 
         json.put("home_server_url", mHsUri.toString());
         json.put("identity_server_url", getIdentityServerUri().toString());
-        if (mAntiVirusServerUri != null) json.put("antivirus_server_url", mAntiVirusServerUri.toString());
+        if (mAntiVirusServerUri != null) {
+            json.put("antivirus_server_url", mAntiVirusServerUri.toString());
+        }
 
         json.put("pin", mPin);
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 OpenMarket Ltd
+ * Copyright 2018 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 package org.matrix.androidsdk;
 
 import android.net.Uri;
+import android.support.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -36,6 +38,8 @@ public class HomeServerConnectionConfig {
     private Uri mHsUri;
     // the identity server URI
     private Uri mIdentityServerUri;
+    // the anti-virus server URI
+    private Uri mAntiVirusServerUri;
     // allowed fingerprints
     private List<Fingerprint> mAllowedFingerprints = new ArrayList<>();
     // the credentials
@@ -52,9 +56,9 @@ public class HomeServerConnectionConfig {
 
     /**
      * @param hsUri       The URI to use to connect to the homeserver
-     * @param credentials The credentials to use, if needed. Can be null.
+     * @param credentials The credentials to use, if needed.
      */
-    public HomeServerConnectionConfig(Uri hsUri, Credentials credentials) {
+    public HomeServerConnectionConfig(Uri hsUri, @Nullable Credentials credentials) {
         this(hsUri, null, credentials, new ArrayList<Fingerprint>(), false);
     }
 
@@ -66,7 +70,7 @@ public class HomeServerConnectionConfig {
      * @param pin                 If true only allow certs matching given fingerprints, otherwise fallback to
      *                            standard X509 checks.
      */
-    public HomeServerConnectionConfig(Uri hsUri, Uri identityServerUri, Credentials credentials, List<Fingerprint> allowedFingerprints, boolean pin) {
+    public HomeServerConnectionConfig(Uri hsUri, @Nullable Uri identityServerUri, @Nullable Credentials credentials, List<Fingerprint> allowedFingerprints, boolean pin) {
         if (hsUri == null || (!"http".equals(hsUri.getScheme()) && !"https".equals(hsUri.getScheme()))) {
             throw new RuntimeException("Invalid home server URI: " + hsUri);
         }
@@ -97,6 +101,7 @@ public class HomeServerConnectionConfig {
 
         mHsUri = hsUri;
         mIdentityServerUri = identityServerUri;
+        mAntiVirusServerUri = null;
 
         if (null != allowedFingerprints) {
             mAllowedFingerprints = allowedFingerprints;
@@ -139,6 +144,23 @@ public class HomeServerConnectionConfig {
     }
 
     /**
+     * Update the anti-virus server URI.
+     *
+     * @param uri the new anti-virus uri
+     */
+    public void setAntiVirusServerUri(Uri uri) {
+        mAntiVirusServerUri = uri;
+    }
+
+    /**
+     * @return the anti-virus server uri
+     */
+    public Uri getAntiVirusServerUri() {
+        // Consider the HS uri by default.
+        return (null == mAntiVirusServerUri) ? mHsUri : mAntiVirusServerUri;
+    }
+
+    /**
      * @return the allowed fingerprints.
      */
     public List<Fingerprint> getAllowedFingerprints() {
@@ -174,6 +196,7 @@ public class HomeServerConnectionConfig {
         return "HomeserverConnectionConfig{" +
                 "mHsUri=" + mHsUri +
                 ", mIdentityServerUri=" + mIdentityServerUri +
+                ", mAntiVirusServerUri=" + mAntiVirusServerUri +
                 ", mAllowedFingerprints size=" + mAllowedFingerprints.size() +
                 ", mCredentials=" + mCredentials +
                 ", mPin=" + mPin +
@@ -191,6 +214,7 @@ public class HomeServerConnectionConfig {
 
         json.put("home_server_url", mHsUri.toString());
         json.put("identity_server_url", getIdentityServerUri().toString());
+        if (mAntiVirusServerUri != null) json.put("antivirus_server_url", mAntiVirusServerUri.toString());
 
         json.put("pin", mPin);
 
@@ -233,6 +257,11 @@ public class HomeServerConnectionConfig {
                 creds,
                 fingerprints,
                 jsonObject.optBoolean("pin", false));
+
+        // Set the anti-virus server uri if any
+        if (jsonObject.has("antivirus_server_url")) {
+            config.setAntiVirusServerUri(Uri.parse(jsonObject.getString("antivirus_server_url")));
+        }
 
         return config;
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
@@ -61,6 +61,7 @@ public class RestClient<T> {
     private static final String LOG_TAG = RestClient.class.getSimpleName();
 
     public static final String URI_API_PREFIX_PATH_MEDIA_R0 = "_matrix/media/r0/";
+    public static final String URI_API_PREFIX_PATH_MEDIA_PROXY_UNSTABLE = "_matrix/media_proxy/unstable/";
     public static final String URI_API_PREFIX_PATH_R0 = "_matrix/client/r0/";
     public static final String URI_API_PREFIX_PATH_UNSTABLE = "_matrix/client/unstable/";
 
@@ -68,6 +69,15 @@ public class RestClient<T> {
      * Prefix used in path of identity server API requests.
      */
     public static final String URI_API_PREFIX_IDENTITY = "_matrix/identity/api/v1/";
+
+    /**
+     * List the servers which should be used to define the base url.
+     */
+    public enum EndPointServer {
+        HOME_SERVER,
+        IDENTITY_SERVER,
+        ANTIVIRUS_SERVER
+    }
 
     protected static final int CONNECTION_TIMEOUT_MS = 30000;
     private static final int READ_TIMEOUT_MS = 60000;
@@ -93,7 +103,7 @@ public class RestClient<T> {
     private OkHttpClient mOkHttpClient = new OkHttpClient();
 
     public RestClient(HomeServerConnectionConfig hsConfig, Class<T> type, String uriPrefix, boolean withNullSerialization) {
-        this(hsConfig, type, uriPrefix, withNullSerialization, false);
+        this(hsConfig, type, uriPrefix, withNullSerialization, EndPointServer.HOME_SERVER);
     }
 
     /**
@@ -106,6 +116,19 @@ public class RestClient<T> {
      * @param useIdentityServer     true to use the identity server URL as base request
      */
     public RestClient(HomeServerConnectionConfig hsConfig, Class<T> type, String uriPrefix, boolean withNullSerialization, boolean useIdentityServer) {
+        this(hsConfig, type, uriPrefix, withNullSerialization, useIdentityServer ? EndPointServer.IDENTITY_SERVER : EndPointServer.HOME_SERVER);
+    }
+
+    /**
+     * Public constructor.
+     *
+     * @param hsConfig              the home server configuration.
+     * @param type                  the REST type
+     * @param uriPrefix             the URL request prefix
+     * @param withNullSerialization true to serialise class member with null value
+     * @param endPointServer        tell which server is used to define the base url
+     */
+    public RestClient(HomeServerConnectionConfig hsConfig, Class<T> type, String uriPrefix, boolean withNullSerialization, EndPointServer endPointServer) {
         // The JSON -> object mapper
         gson = JsonUtils.getGson(withNullSerialization);
 
@@ -172,7 +195,7 @@ public class RestClient<T> {
         }
 
         mOkHttpClient = okHttpClientBuilder.build();
-        final String endPoint = makeEndpoint(hsConfig, uriPrefix, useIdentityServer);
+        final String endPoint = makeEndpoint(hsConfig, uriPrefix, endPointServer);
 
         // Rest adapter for turning API interfaces into actual REST-calling objects
         Retrofit.Builder builder = new Retrofit.Builder()
@@ -187,10 +210,22 @@ public class RestClient<T> {
     }
 
     @NonNull
-    private String makeEndpoint(HomeServerConnectionConfig hsConfig, String uriPrefix, boolean useIdentityServer) {
-        String baseUrl = useIdentityServer
-                ? hsConfig.getIdentityServerUri().toString()
-                : hsConfig.getHomeserverUri().toString();
+    private String makeEndpoint(HomeServerConnectionConfig hsConfig, String uriPrefix, EndPointServer endPointServer) {
+        String baseUrl;
+        switch (endPointServer) {
+            case HOME_SERVER:
+                baseUrl = hsConfig.getHomeserverUri().toString();
+                break;
+            case IDENTITY_SERVER:
+                baseUrl = hsConfig.getIdentityServerUri().toString();
+                break;
+            case ANTIVIRUS_SERVER:
+                baseUrl = hsConfig.getAntiVirusServerUri().toString();
+                break;
+            default:
+                baseUrl = hsConfig.getHomeserverUri().toString();
+
+        }
         baseUrl = sanitizeBaseUrl(baseUrl);
         String dynamicPath = sanitizeDynamicPath(uriPrefix);
         return baseUrl + dynamicPath;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
@@ -213,15 +213,13 @@ public class RestClient<T> {
     private String makeEndpoint(HomeServerConnectionConfig hsConfig, String uriPrefix, EndPointServer endPointServer) {
         String baseUrl;
         switch (endPointServer) {
-            case HOME_SERVER:
-                baseUrl = hsConfig.getHomeserverUri().toString();
-                break;
             case IDENTITY_SERVER:
                 baseUrl = hsConfig.getIdentityServerUri().toString();
                 break;
             case ANTIVIRUS_SERVER:
                 baseUrl = hsConfig.getAntiVirusServerUri().toString();
                 break;
+            case HOME_SERVER:
             default:
                 baseUrl = hsConfig.getHomeserverUri().toString();
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
@@ -51,9 +51,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.ObjectOutputStream;
 import java.lang.ref.WeakReference;
+import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -74,7 +75,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
     /**
      * Pending media URLs
      */
-    private static final HashMap<String, MXMediaDownloadWorkerTask> mPendingDownloadByUrl = new HashMap<>();
+    private static final HashMap<String, MXMediaDownloadWorkerTask> mPendingDownloadById = new HashMap<>();
 
     /**
      * List of unreachable media urls.
@@ -87,7 +88,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
     /**
      * The medias cache
      */
-    private static LruCache<String, Bitmap> mBitmapByUrlCache = null;
+    private static LruCache<String, Bitmap> mBitmapByDownloadIdCache = null;
 
     /**
      * The downloaded media callbacks.
@@ -103,6 +104,16 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
      * The media URL.
      */
     private String mUrl;
+
+    /**
+     * The download identifier based on the original matrix content url for this media.
+     */
+    private String mDownloadId;
+
+    /**
+     * Tells if the anti-virus scanner is enabled.
+     */
+    private boolean mIsAvScannerEnabled = false;
 
     /**
      * The media mime type
@@ -179,22 +190,22 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
      */
     public static void clearBitmapsCache() {
         // sMemoryCache can be null if no bitmap have been downloaded.
-        if (null != mBitmapByUrlCache) {
-            mBitmapByUrlCache.evictAll();
+        if (null != mBitmapByDownloadIdCache) {
+            mBitmapByDownloadIdCache.evictAll();
         }
     }
 
     /**
-     * Check if there is a pending download for the url.
+     * Check if there is a pending download with the provided id.
      *
-     * @param url The url to check the existence
+     * @param downloadId The identifier to check
      * @return the dedicated MXMediaDownloadWorkerTask if it exists.
      */
-    public static MXMediaDownloadWorkerTask getMediaDownloadWorkerTask(String url) {
-        if ((url != null) && mPendingDownloadByUrl.containsKey(url)) {
+    public static MXMediaDownloadWorkerTask getMediaDownloadWorkerTask(String downloadId) {
+        if (mPendingDownloadById.containsKey(downloadId)) {
             MXMediaDownloadWorkerTask task;
-            synchronized (mPendingDownloadByUrl) {
-                task = mPendingDownloadByUrl.get(url);
+            synchronized (mPendingDownloadById) {
+                task = mPendingDownloadById.get(downloadId);
             }
             return task;
         } else {
@@ -259,17 +270,17 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
     }
 
     /**
-     * Tell if the media is cached
+     * Tell if the media is cached with the provided cache identifier
      *
-     * @param url the media url
-     * @return true if the media is cached
+     * @param mediaCacheId
+     * @return true if a media is cached with this identifier
      */
-    public static boolean isUrlCached(String url) {
+    public static boolean isMediaCached(String mediaCacheId) {
         boolean res = false;
 
-        if ((null != mBitmapByUrlCache) && (null != url)) {
+        if ((null != mBitmapByDownloadIdCache)) {
             synchronized (mSyncObject) {
-                res = (null != mBitmapByUrlCache.get(url));
+                res = (null != mBitmapByDownloadIdCache.get(mediaCacheId));
             }
         }
 
@@ -299,7 +310,8 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
      * rotationAngle is set to Integer.MAX_VALUE when undefined : the EXIF metadata must be checked.
      *
      * @param baseFile       the base file
-     * @param url            the media url
+     * @param url            the actual media url
+     * @param downloadId     the predefined id of the download task for this content
      * @param aRotation      the bitmap rotation
      * @param mimeType       the mime type
      * @param encryptionInfo the encryption information
@@ -308,6 +320,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
     static boolean bitmapForURL(final Context context,
                                 final File baseFile,
                                 final String url,
+                                final String downloadId,
                                 final int aRotation,
                                 final String mimeType,
                                 final EncryptedFileInfo encryptionInfo,
@@ -317,13 +330,12 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
             return false;
         }
 
-
-        if (null == mBitmapByUrlCache) {
+        if (null == mBitmapByDownloadIdCache) {
             int lruSize = Math.min(20 * 1024 * 1024, (int) Runtime.getRuntime().maxMemory() / 8);
 
             Log.d(LOG_TAG, "bitmapForURL  lruSize : " + lruSize);
 
-            mBitmapByUrlCache = new LruCache<String, Bitmap>(lruSize) {
+            mBitmapByDownloadIdCache = new LruCache<String, Bitmap>(lruSize) {
                 @Override
                 protected int sizeOf(String key, Bitmap bitmap) {
                     return bitmap.getRowBytes() * bitmap.getHeight(); // size in bytes
@@ -332,7 +344,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
         }
 
         // the image is downloading in background
-        if (null != getMediaDownloadWorkerTask(url)) {
+        if (null != getMediaDownloadWorkerTask(downloadId)) {
             return false;
         }
 
@@ -344,7 +356,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
         final Bitmap cachedBitmap;
 
         synchronized (mSyncObject) {
-            cachedBitmap = mBitmapByUrlCache.get(url);
+            cachedBitmap = mBitmapByDownloadIdCache.get(downloadId);
         }
 
         if (null != cachedBitmap) {
@@ -383,7 +395,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
         // not a valid file name
         if (null == filename) {
-            filename = buildFileName(url, mimeType);
+            filename = buildFileName(downloadId, mimeType);
         }
 
         final String fFilename = filename;
@@ -455,7 +467,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
                                 // it would replace small ones.
                                 // let assume that the application must be faster when showing the chat history.
                                 if ((bitmap.getWidth() < 1000) && (bitmap.getHeight() < 1000)) {
-                                    mBitmapByUrlCache.put(url, bitmap);
+                                    mBitmapByDownloadIdCache.put(downloadId, bitmap);
                                 }
                             }
                         }
@@ -488,49 +500,6 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
     //==============================================================================================================
 
     /**
-     * Shared initialization methods.
-     *
-     * @param appContext the application context.
-     * @param url        the media URL.
-     * @param mimeType   the mime type.
-     */
-    private void commonInit(Context appContext, String url, String mimeType) {
-        mApplicationContext = appContext;
-        mUrl = url;
-        synchronized (mPendingDownloadByUrl) {
-            mPendingDownloadByUrl.put(url, this);
-        }
-        mMimeType = mimeType;
-        mRotation = 0;
-    }
-
-    /**
-     * MXMediaDownloadWorkerTask creator
-     *
-     * @param appContext                  the context
-     * @param hsConfig                    the home server config.
-     * @param networkConnectivityReceiver the network connectivity receiver
-     * @param directoryFile               the directory in which the media must be stored
-     * @param url                         the media url
-     * @param mimeType                    the mime type.
-     * @param encryptedFileInfo           the encryption information
-     */
-    public MXMediaDownloadWorkerTask(Context appContext,
-                                     HomeServerConnectionConfig hsConfig,
-                                     NetworkConnectivityReceiver networkConnectivityReceiver,
-                                     File directoryFile,
-                                     String url,
-                                     String mimeType,
-                                     EncryptedFileInfo encryptedFileInfo) {
-        commonInit(appContext, url, mimeType);
-        mNetworkConnectivityReceiver = networkConnectivityReceiver;
-        mDirectoryFile = directoryFile;
-        mImageViewReferences = new ArrayList<>();
-        mHsConfig = hsConfig;
-        mEncryptedFileInfo = encryptedFileInfo;
-    }
-
-    /**
      * MXMediaDownloadWorkerTask creator
      *
      * @param appContext                  the context
@@ -538,25 +507,36 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
      * @param networkConnectivityReceiver the network connectivity receiver
      * @param directoryFile               the directory in which the media must be stored
      * @param url                         the media url
-     * @param rotation                    the rotation
+     * @param downloadId                  the predefined id of the download task for this content
+     * @param rotation                    the rotation angle (degrees), use 0 by default
      * @param mimeType                    the mime type.
      * @param encryptedFileInfo           the encryption information
+     * @param isAvScannerEnabled          tell whether an anti-virus scanner is enabled
      */
     public MXMediaDownloadWorkerTask(Context appContext,
                                      HomeServerConnectionConfig hsConfig,
                                      NetworkConnectivityReceiver networkConnectivityReceiver,
                                      File directoryFile,
                                      String url,
+                                     String downloadId,
                                      int rotation,
                                      String mimeType,
-                                     EncryptedFileInfo encryptedFileInfo) {
-        commonInit(appContext, url, mimeType);
+                                     EncryptedFileInfo encryptedFileInfo,
+                                     boolean isAvScannerEnabled) {
+        mApplicationContext = appContext;
+        mUrl = url;
+        mDownloadId = downloadId;
+        synchronized (mPendingDownloadById) {
+            mPendingDownloadById.put(downloadId, this);
+        }
+        mMimeType = mimeType;
         mNetworkConnectivityReceiver = networkConnectivityReceiver;
         mImageViewReferences = new ArrayList<>();
         mDirectoryFile = directoryFile;
         mRotation = rotation;
         mHsConfig = hsConfig;
         mEncryptedFileInfo = encryptedFileInfo;
+        mIsAvScannerEnabled = isAvScannerEnabled;
     }
 
     /**
@@ -567,15 +547,18 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
     public MXMediaDownloadWorkerTask(MXMediaDownloadWorkerTask task) {
         mApplicationContext = task.mApplicationContext;
         mUrl = task.mUrl;
-        mRotation = task.mRotation;
-        synchronized (mPendingDownloadByUrl) {
-            mPendingDownloadByUrl.put(mUrl, this);
+        mDownloadId = task.mDownloadId;
+        synchronized (mPendingDownloadById) {
+            mPendingDownloadById.put(mDownloadId, this);
         }
         mMimeType = task.mMimeType;
+        mNetworkConnectivityReceiver = task.mNetworkConnectivityReceiver;
         mImageViewReferences = task.mImageViewReferences;
+        mDirectoryFile = task.mDirectoryFile;
+        mRotation = task.mRotation;
         mHsConfig = task.mHsConfig;
         mEncryptedFileInfo = task.mEncryptedFileInfo;
-        mNetworkConnectivityReceiver = task.mNetworkConnectivityReceiver;
+        mIsAvScannerEnabled = task.mIsAvScannerEnabled;
     }
 
     /**
@@ -708,10 +691,10 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
             InputStream stream = null;
 
             int filelen = -1;
-            URLConnection connection = null;
+            HttpURLConnection connection = null;
 
             try {
-                connection = url.openConnection();
+                connection = (HttpURLConnection)url.openConnection();
 
                 if (mHsConfig != null && connection instanceof HttpsURLConnection) {
                     // Add SSL Socket factory.
@@ -728,6 +711,19 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
                 // add a timeout to avoid infinite loading display.
                 float scale = (null != mNetworkConnectivityReceiver) ? mNetworkConnectivityReceiver.getTimeoutScale() : 1.0f;
                 connection.setReadTimeout((int) (DOWNLOAD_TIME_OUT * scale));
+
+                if (mIsAvScannerEnabled && null != mEncryptedFileInfo) {
+                    // POST the encryption info to let the av scanner decrypt and scan the content.
+                    connection.setRequestMethod("POST");
+                    try {
+                        ObjectOutputStream body = new ObjectOutputStream(connection.getOutputStream());
+                        body.writeObject(mEncryptedFileInfo);
+                        body.close();
+                    } catch (Exception e) {
+                        Log.e(LOG_TAG, "doInBackground Failed to serialize encryption info " + e.getMessage());
+                    }
+                }
+
                 filelen = connection.getContentLength();
                 stream = connection.getInputStream();
             } catch (Exception e) {
@@ -759,6 +755,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
                 // if some medias are not found
                 // do not try to reload them until the next application launch.
+                // TODO check what happen with the commun url for encrypted content
                 synchronized (mUnreachableUrls) {
                     mUnreachableUrls.add(mUrl);
                 }
@@ -772,6 +769,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
                 // if some medias are not found
                 // do not try to reload them until the next application launch.
+                // TODO check what happen with the commun url for encrypted content
                 synchronized (mUnreachableUrls) {
                     mUnreachableUrls.add(mUrl);
                 }
@@ -781,7 +779,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
             if (!isDownloadCancelled() && (null == mErrorAsJsonElement)) {
                 final long startDownloadTime = System.currentTimeMillis();
 
-                String filename = MXMediaDownloadWorkerTask.buildFileName(mUrl, mMimeType) + ".tmp";
+                String filename = MXMediaDownloadWorkerTask.buildFileName(mDownloadId, mMimeType) + ".tmp";
                 FileOutputStream fos = new FileOutputStream(new File(mDirectoryFile, filename));
 
                 mDownloadStats.mDownloadId = mUrl;
@@ -859,7 +857,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
                 if (mDownloadStats.mProgress == 100) {
                     try {
                         File originalFile = new File(mDirectoryFile, filename);
-                        String newFileName = MXMediaDownloadWorkerTask.buildFileName(mUrl, mMimeType);
+                        String newFileName = MXMediaDownloadWorkerTask.buildFileName(mDownloadId, mMimeType);
                         File newFile = new File(mDirectoryFile, newFileName);
                         if (newFile.exists()) {
                             // Or you could throw here.
@@ -893,8 +891,8 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
         }
 
         // remove the image from the loading one
-        synchronized (mPendingDownloadByUrl) {
-            mPendingDownloadByUrl.remove(mUrl);
+        synchronized (mPendingDownloadById) {
+            mPendingDownloadById.remove(mDownloadId);
         }
 
         return null;
@@ -933,7 +931,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
             // update the linked ImageViews.
             if (isBitmapDownloadTask()) {
                 // retrieve the bitmap from the file s
-                if (!MXMediaDownloadWorkerTask.bitmapForURL(mApplicationContext, mDirectoryFile, mUrl, mRotation, mMimeType, mEncryptedFileInfo,
+                if (!MXMediaDownloadWorkerTask.bitmapForURL(mApplicationContext, mDirectoryFile, mUrl, mDownloadId, mRotation, mMimeType, mEncryptedFileInfo,
                         new SimpleApiCallback<Bitmap>() {
                     @Override
                     public void onSuccess(Bitmap bitmap) {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
@@ -729,7 +729,7 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
                 Log.e(LOG_TAG, "bitmapForURL : fail to open the connection " + e.getMessage());
                 defaultError.error = e.getLocalizedMessage();
 
-                InputStream errorStream = ((HttpsURLConnection) connection).getErrorStream();
+                InputStream errorStream = connection.getErrorStream();
 
                 if (null != errorStream) {
                     try {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
@@ -189,7 +189,6 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
      * Clear the internal cache.
      */
     public static void clearBitmapsCache() {
-        // sMemoryCache can be null if no bitmap have been downloaded.
         if (null != mBitmapByDownloadIdCache) {
             mBitmapByDownloadIdCache.evictAll();
         }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -113,7 +113,7 @@ public class MXMediasCache {
         File mediaBaseFolderFile;
 
         // Clear previous cache
-        for(String previousMediaCacheFolder: sPreviousMediaCacheFolders) {
+        for (String previousMediaCacheFolder: sPreviousMediaCacheFolders) {
             mediaBaseFolderFile = new File(context.getApplicationContext().getFilesDir(), previousMediaCacheFolder);
 
             if (mediaBaseFolderFile.exists()) {
@@ -1137,7 +1137,15 @@ public class MXMediasCache {
             } else {
                 // Download it in background
                 MXMediaDownloadWorkerTask task = new MXMediaDownloadWorkerTask(context,
-                        hsConfig, mNetworkConnectivityReceiver, folderFile, downloadableUrl, downloadId, rotationAngle, mimeType, encryptionInfo, mContentManager.isAvScannerEnabled());
+                        hsConfig,
+                        mNetworkConnectivityReceiver,
+                        folderFile,
+                        downloadableUrl,
+                        downloadId,
+                        rotationAngle,
+                        mimeType,
+                        encryptionInfo,
+                        mContentManager.isAvScannerEnabled());
 
                 if (null != imageView) {
                     task.addImageView(imageView);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -199,7 +199,9 @@ public class MXMediasCache {
         AsyncTask<Void, Void, Long> task = new AsyncTask<Void, Void, Long>() {
             @Override
             protected Long doInBackground(Void... params) {
-                return ContentUtils.getDirectorySize(context, new File(context.getApplicationContext().getFilesDir(), MXMEDIA_STORE_FOLDER_NEW), 1);
+                return ContentUtils.getDirectorySize(context,
+                        new File(context.getApplicationContext().getFilesDir(), MXMEDIA_STORE_FOLDER_NEW),
+                        1);
             }
 
             @Override
@@ -310,7 +312,7 @@ public class MXMediasCache {
 
         if (null != thumbnailCacheId) {
             if (size > 0) {
-                thumbnailCacheId += "?width=" + size + "&height=" + size;
+                thumbnailCacheId += "_w_" + size + "_h_" + size;
             }
             String filename = MXMediaDownloadWorkerTask.buildFileName(thumbnailCacheId, "image/jpeg");
 
@@ -352,7 +354,7 @@ public class MXMediasCache {
             String cacheId = mContentManager.downloadTaskIdForMatrixMediaContent(url);
             if (null != cacheId) {
                 if ((width > 0) && (height > 0)) {
-                    cacheId += "?width=" + width + "&height=" + height;
+                    cacheId += "_w_" + width + "_h_" + height;
                 }
                 filename = MXMediaDownloadWorkerTask.buildFileName(cacheId, mimeType);
             } else {
@@ -634,7 +636,7 @@ public class MXMediasCache {
         String cacheId = mContentManager.downloadTaskIdForMatrixMediaContent(mediaUrl);
         if (null != cacheId) {
             if ((width > 0) && (height > 0)) {
-                cacheId += "?width=" + width + "&height=" + height;
+                cacheId += "_w_" + width + "_h_" + height;
             }
             String filename = MXMediaDownloadWorkerTask.buildFileName(cacheId, mimeType);
 
@@ -720,7 +722,7 @@ public class MXMediasCache {
         String thumbnailCacheId = mContentManager.downloadTaskIdForMatrixMediaContent(url);
         if (null != thumbnailCacheId) {
             if (size > 0) {
-                thumbnailCacheId += "?width=" + size + "&height=" + size;
+                thumbnailCacheId += "_w_" + size + "_h_" + size;
             }
             isCached = MXMediaDownloadWorkerTask.isMediaCached(thumbnailCacheId);
 
@@ -899,7 +901,7 @@ public class MXMediasCache {
         // Download it in background
         String downloadableUrl = mContentManager.getDownloadableUrl(url, null != encryptionInfo);
         task = new MXMediaDownloadWorkerTask(context, hsConfig, mNetworkConnectivityReceiver, getFolderFile(mimeType), downloadableUrl, downloadId, 0, mimeType,
-                encryptionInfo, mContentManager.isIsAvScannerEnabled());
+                encryptionInfo, mContentManager.isAvScannerEnabled());
         task.addDownloadListener(listener);
 
         // avoid crash if there are too many running task
@@ -1069,7 +1071,7 @@ public class MXMediasCache {
         String downloadableUrl;
         if (null == encryptionInfo && width > 0 && height > 0) {
             downloadableUrl = mContentManager.getDownloadableThumbnailUrl(url, width, height, ContentManager.METHOD_SCALE);
-            downloadId += "?width=" + width + "&height=" + height;
+            downloadId += "_w_" + width + "_h_" + height;
         } else {
             downloadableUrl = mContentManager.getDownloadableUrl(url, true);
         }
@@ -1081,11 +1083,10 @@ public class MXMediasCache {
                 && (orientation != ExifInterface.ORIENTATION_NORMAL)) {
             if (downloadableUrl.contains("?")) {
                 downloadableUrl += "&apply_orientation=true";
-                downloadId += "&apply_orientation=true";
             } else {
                 downloadableUrl += "?apply_orientation=true";
-                downloadId += "?apply_orientation=true";
             }
+            downloadId += "_apply_orientation";
         }
 
         final String fDownloadableUrl = downloadId;
@@ -1124,7 +1125,7 @@ public class MXMediasCache {
             } else {
                 // Download it in background
                 MXMediaDownloadWorkerTask task = new MXMediaDownloadWorkerTask(context,
-                        hsConfig, mNetworkConnectivityReceiver, folderFile, downloadableUrl, downloadId, rotationAngle, mimeType, encryptionInfo, mContentManager.isIsAvScannerEnabled());
+                        hsConfig, mNetworkConnectivityReceiver, folderFile, downloadableUrl, downloadId, rotationAngle, mimeType, encryptionInfo, mContentManager.isAvScannerEnabled());
 
                 if (null != imageView) {
                     task.addImageView(imageView);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -1073,7 +1073,7 @@ public class MXMediasCache {
             downloadableUrl = mContentManager.getDownloadableThumbnailUrl(url, width, height, ContentManager.METHOD_SCALE);
             downloadId += "_w_" + width + "_h_" + height;
         } else {
-            downloadableUrl = mContentManager.getDownloadableUrl(url, true);
+            downloadableUrl = mContentManager.getDownloadableUrl(url, null != encryptionInfo);
         }
 
         // the thumbnail params are ignored when encrypted

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/MediaScanApi.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/MediaScanApi.java
@@ -15,8 +15,8 @@
  */
 package org.matrix.androidsdk.rest.api;
 
+import org.matrix.androidsdk.rest.model.EncryptedMediaScanBody;
 import org.matrix.androidsdk.rest.model.MediaScanResult;
-import org.matrix.androidsdk.rest.model.crypto.EncryptedFileInfo;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
@@ -40,8 +40,8 @@ public interface MediaScanApi {
     /**
      * Scan an encrypted file.
      *
-     * @param encryptedFileInfo the encrypted file information
+     * @param encryptedMediaScanBody the encryption information required to decrypt the content before scanning it.
      */
     @POST("scan_encrypted")
-    Call<MediaScanResult> scanEncrypted(@Body EncryptedFileInfo encryptedFileInfo);
+    Call<MediaScanResult> scanEncrypted(@Body EncryptedMediaScanBody encryptedMediaScanBody);
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/MediaScanApi.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/MediaScanApi.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.matrix.androidsdk.rest.api;
+
+import org.matrix.androidsdk.rest.model.MediaScanResult;
+import org.matrix.androidsdk.rest.model.crypto.EncryptedFileInfo;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+/**
+ * The matrix content scanner REST API.
+ */
+public interface MediaScanApi {
+    /**
+     * Scan an unencrypted file.
+     *
+     * @param domain the server name
+     * @param mediaId the user id
+     */
+    @GET("scan/{domain}/{mediaId}")
+    Call<MediaScanResult> scanUnencrypted(@Path("domain") String domain, @Path("mediaId") String mediaId);
+
+    /**
+     * Scan an encrypted file.
+     *
+     * @param encryptedFileInfo the encrypted file information
+     */
+    @POST("scan_encrypted")
+    Call<MediaScanResult> scanEncrypted(@Body EncryptedFileInfo encryptedFileInfo);
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/MediaScanRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/MediaScanRestClient.java
@@ -20,6 +20,7 @@ import org.matrix.androidsdk.RestClient;
 import org.matrix.androidsdk.rest.api.MediaScanApi;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.DefaultRetrofit2CallbackWrapper;
+import org.matrix.androidsdk.rest.model.EncryptedMediaScanBody;
 import org.matrix.androidsdk.rest.model.MediaScanResult;
 import org.matrix.androidsdk.rest.model.crypto.EncryptedFileInfo;
 
@@ -50,11 +51,11 @@ public class MediaScanRestClient extends RestClient<MediaScanApi> {
     /**
      * Scan an encrypted file.
      *
-     * @param encryptedFileInfo the encryption information
+     * @param encryptedMediaScanBody the encryption information required to decrypt the content before scanning it.
      * @param callback on success callback containing a MediaScanResult object
      */
-    public void scanEncryptedFile(final EncryptedFileInfo encryptedFileInfo, final ApiCallback<MediaScanResult> callback) {
+    public void scanEncryptedFile(final EncryptedMediaScanBody encryptedMediaScanBody, final ApiCallback<MediaScanResult> callback) {
 
-        mApi.scanEncrypted(encryptedFileInfo).enqueue(new DefaultRetrofit2CallbackWrapper<>(callback));
+        mApi.scanEncrypted(encryptedMediaScanBody).enqueue(new DefaultRetrofit2CallbackWrapper<>(callback));
     }
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/MediaScanRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/MediaScanRestClient.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.matrix.androidsdk.rest.client;
+
+import org.matrix.androidsdk.HomeServerConnectionConfig;
+import org.matrix.androidsdk.RestClient;
+import org.matrix.androidsdk.rest.api.MediaScanApi;
+import org.matrix.androidsdk.rest.callback.ApiCallback;
+import org.matrix.androidsdk.rest.callback.DefaultRetrofit2CallbackWrapper;
+import org.matrix.androidsdk.rest.model.MediaScanResult;
+import org.matrix.androidsdk.rest.model.crypto.EncryptedFileInfo;
+
+/**
+ * Class used to make requests to the anti-virus scanner API.
+ */
+public class MediaScanRestClient extends RestClient<MediaScanApi> {
+
+    /**
+     * {@inheritDoc}
+     */
+    public MediaScanRestClient(HomeServerConnectionConfig hsConfig) {
+        super(hsConfig, MediaScanApi.class, RestClient.URI_API_PREFIX_PATH_MEDIA_PROXY_UNSTABLE, false, EndPointServer.ANTIVIRUS_SERVER);
+    }
+
+    /**
+     * Scan an unencrypted file.
+     *
+     * @param domain   the server name extracted from the matrix content uri
+     * @param mediaId   the media id extracted from the matrix content uri
+     * @param callback on success callback containing a MediaScanResult object
+     */
+    public void scanUnencryptedFile(final String domain, final String mediaId, final ApiCallback<MediaScanResult> callback) {
+
+        mApi.scanUnencrypted(domain, mediaId).enqueue(new DefaultRetrofit2CallbackWrapper<>(callback));
+    }
+
+    /**
+     * Scan an encrypted file.
+     *
+     * @param encryptedFileInfo the encryption information
+     * @param callback on success callback containing a MediaScanResult object
+     */
+    public void scanEncryptedFile(final EncryptedFileInfo encryptedFileInfo, final ApiCallback<MediaScanResult> callback) {
+
+        mApi.scanEncrypted(encryptedFileInfo).enqueue(new DefaultRetrofit2CallbackWrapper<>(callback));
+    }
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/EncryptedMediaScanBody.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/EncryptedMediaScanBody.java
@@ -15,12 +15,15 @@
  */
 package org.matrix.androidsdk.rest.model;
 
+import com.google.gson.annotations.SerializedName;
+
+import org.matrix.androidsdk.rest.model.crypto.EncryptedFileInfo;
+
 /**
- * Class to contain the anti-virus scan result of a matrix content.
+ * Class to prepare the request body used to scan an encrypted content.
  */
-public class MediaScanResult {
-    // If true, the script ran with an exit code of 0. Otherwise it ran with a non-zero exit code.
-    public boolean clean;
-    // Human-readable information about the result.
-    public String info;
+public class EncryptedMediaScanBody {
+    // The encryption information used to decrypt the content before scanning it
+    @SerializedName("file")
+    public EncryptedFileInfo encryptedFileInfo;
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -29,6 +29,7 @@ import org.matrix.androidsdk.db.MXMediasCache;
 import org.matrix.androidsdk.rest.model.crypto.EncryptedFileInfo;
 import org.matrix.androidsdk.rest.model.message.FileMessage;
 import org.matrix.androidsdk.rest.model.message.ImageMessage;
+import org.matrix.androidsdk.rest.model.message.LocationMessage;
 import org.matrix.androidsdk.rest.model.message.Message;
 import org.matrix.androidsdk.rest.model.message.StickerMessage;
 import org.matrix.androidsdk.rest.model.message.VideoMessage;
@@ -645,7 +646,7 @@ public class Event implements Externalizable {
      * @return the media URLs defined in the event.
      */
     public List<String> getMediaUrls() {
-        ArrayList<String> urls = new ArrayList<>();
+        List<String> urls = new ArrayList<>();
 
         if (Event.EVENT_TYPE_MESSAGE.equals(getType())) {
             String msgType = JsonUtils.getMessageMsgType(getContent());
@@ -674,6 +675,12 @@ public class Event implements Externalizable {
                 if (null != videoMessage.getThumbnailUrl()) {
                     urls.add(videoMessage.getThumbnailUrl());
                 }
+            } else if (Message.MSGTYPE_LOCATION.equals(msgType)) {
+                LocationMessage locationMessage = JsonUtils.toLocationMessage(getContent());
+
+                if (null != locationMessage.thumbnail_url) {
+                    urls.add(locationMessage.thumbnail_url);
+                }
             }
         } else if (Event.EVENT_TYPE_STICKER.equals(getType())) {
             StickerMessage stickerMessage = JsonUtils.toStickerMessage(getContent());
@@ -694,11 +701,11 @@ public class Event implements Externalizable {
      * @return all the encrypted file infos defined in the event.
      */
     public List<EncryptedFileInfo> getEncryptedFileInfos() {
-        ArrayList<EncryptedFileInfo> urls = new ArrayList<>();
+        List<EncryptedFileInfo> encryptedFileInfos = new ArrayList<>();
 
         if (!isEncrypted()) {
             // return empty array
-            return urls;
+            return encryptedFileInfos;
         }
 
         if (Event.EVENT_TYPE_MESSAGE.equals(getType())) {
@@ -708,39 +715,39 @@ public class Event implements Externalizable {
                 ImageMessage imageMessage = JsonUtils.toImageMessage(getContent());
 
                 if (null != imageMessage.file) {
-                    urls.add(imageMessage.file);
+                    encryptedFileInfos.add(imageMessage.file);
                 }
                 if (null != imageMessage.info && null != imageMessage.info.thumbnail_file) {
-                    urls.add(imageMessage.info.thumbnail_file);
+                    encryptedFileInfos.add(imageMessage.info.thumbnail_file);
                 }
             } else if (Message.MSGTYPE_FILE.equals(msgType) || Message.MSGTYPE_AUDIO.equals(msgType)) {
                 FileMessage fileMessage = JsonUtils.toFileMessage(getContent());
 
                 if (null != fileMessage.file) {
-                    urls.add(fileMessage.file);
+                    encryptedFileInfos.add(fileMessage.file);
                 }
             } else if (Message.MSGTYPE_VIDEO.equals(msgType)) {
                 VideoMessage videoMessage = JsonUtils.toVideoMessage(getContent());
 
                 if (null != videoMessage.file) {
-                    urls.add(videoMessage.file);
+                    encryptedFileInfos.add(videoMessage.file);
                 }
                 if (null != videoMessage.info && null != videoMessage.info.thumbnail_file) {
-                    urls.add(videoMessage.info.thumbnail_file);
+                    encryptedFileInfos.add(videoMessage.info.thumbnail_file);
                 }
             }
         } else if (Event.EVENT_TYPE_STICKER.equals(getType())) {
             StickerMessage stickerMessage = JsonUtils.toStickerMessage(getContent());
 
             if (null != stickerMessage.file) {
-                urls.add(stickerMessage.file);
+                encryptedFileInfos.add(stickerMessage.file);
             }
             if (null != stickerMessage.info && null != stickerMessage.info.thumbnail_file) {
-                urls.add(stickerMessage.info.thumbnail_file);
+                encryptedFileInfos.add(stickerMessage.info.thumbnail_file);
             }
         }
 
-        return urls;
+        return encryptedFileInfos;
     }
 
     /**

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonParser;
 import org.matrix.androidsdk.crypto.MXCryptoError;
 import org.matrix.androidsdk.crypto.MXEventDecryptionResult;
 import org.matrix.androidsdk.db.MXMediasCache;
+import org.matrix.androidsdk.rest.model.crypto.EncryptedFileInfo;
 import org.matrix.androidsdk.rest.model.message.FileMessage;
 import org.matrix.androidsdk.rest.model.message.ImageMessage;
 import org.matrix.androidsdk.rest.model.message.Message;
@@ -655,7 +656,6 @@ public class Event implements Externalizable {
                 if (null != imageMessage.getUrl()) {
                     urls.add(imageMessage.getUrl());
                 }
-
                 if (null != imageMessage.getThumbnailUrl()) {
                     urls.add(imageMessage.getThumbnailUrl());
                 }
@@ -671,6 +671,9 @@ public class Event implements Externalizable {
                 if (null != videoMessage.getUrl()) {
                     urls.add(videoMessage.getUrl());
                 }
+                if (null != videoMessage.getThumbnailUrl()) {
+                    urls.add(videoMessage.getThumbnailUrl());
+                }
             }
         } else if (Event.EVENT_TYPE_STICKER.equals(getType())) {
             StickerMessage stickerMessage = JsonUtils.toStickerMessage(getContent());
@@ -681,6 +684,59 @@ public class Event implements Externalizable {
 
             if (null != stickerMessage.getThumbnailUrl()) {
                 urls.add(stickerMessage.getThumbnailUrl());
+            }
+        }
+
+        return urls;
+    }
+
+    /**
+     * @return all the encrypted file infos defined in the event.
+     */
+    public List<EncryptedFileInfo> getEncryptedFileInfos() {
+        ArrayList<EncryptedFileInfo> urls = new ArrayList<>();
+
+        if (!isEncrypted()) {
+            // return empty array
+            return urls;
+        }
+
+        if (Event.EVENT_TYPE_MESSAGE.equals(getType())) {
+            String msgType = JsonUtils.getMessageMsgType(getContent());
+
+            if (Message.MSGTYPE_IMAGE.equals(msgType)) {
+                ImageMessage imageMessage = JsonUtils.toImageMessage(getContent());
+
+                if (null != imageMessage.file) {
+                    urls.add(imageMessage.file);
+                }
+                if (null != imageMessage.info && null != imageMessage.info.thumbnail_file) {
+                    urls.add(imageMessage.info.thumbnail_file);
+                }
+            } else if (Message.MSGTYPE_FILE.equals(msgType) || Message.MSGTYPE_AUDIO.equals(msgType)) {
+                FileMessage fileMessage = JsonUtils.toFileMessage(getContent());
+
+                if (null != fileMessage.file) {
+                    urls.add(fileMessage.file);
+                }
+            } else if (Message.MSGTYPE_VIDEO.equals(msgType)) {
+                VideoMessage videoMessage = JsonUtils.toVideoMessage(getContent());
+
+                if (null != videoMessage.file) {
+                    urls.add(videoMessage.file);
+                }
+                if (null != videoMessage.info && null != videoMessage.info.thumbnail_file) {
+                    urls.add(videoMessage.info.thumbnail_file);
+                }
+            }
+        } else if (Event.EVENT_TYPE_STICKER.equals(getType())) {
+            StickerMessage stickerMessage = JsonUtils.toStickerMessage(getContent());
+
+            if (null != stickerMessage.file) {
+                urls.add(stickerMessage.file);
+            }
+            if (null != stickerMessage.info && null != stickerMessage.info.thumbnail_file) {
+                urls.add(stickerMessage.info.thumbnail_file);
             }
         }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/MediaScanResult.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/MediaScanResult.java
@@ -1,0 +1,28 @@
+/* 
+ * Copyright 2018 New Vector Ltd
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.matrix.androidsdk.rest.model;
+
+import java.io.Serializable;
+
+/**
+ * Class to contain the anti-virus scan result of a matrix content.
+ */
+public class MediaScanResult implements Serializable {
+    // If true, the script ran with an exit code of 0. Otherwise it ran with a non-zero exit code.
+    public boolean clean;
+    // Human-readable information about the result.
+    public String info;
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
@@ -74,7 +74,7 @@ public class ContentManager {
         }
     }
 
-    public boolean isIsAvScannerEnabled() {
+    public boolean isAvScannerEnabled() {
         return mIsAvScannerEnabled;
     }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
@@ -19,6 +19,7 @@ package org.matrix.androidsdk.util;
 import android.support.annotation.Nullable;
 
 import org.matrix.androidsdk.HomeServerConnectionConfig;
+import org.matrix.androidsdk.RestClient;
 
 /**
  * Class for accessing content from the current session.
@@ -32,7 +33,6 @@ public class ContentManager {
     public static final String METHOD_SCALE = "scale";
 
     public static final String URI_PREFIX_CONTENT_API = "/_matrix/media/v1/";
-    private static final String URI_PREFIX_MEDIA_PROXY_API = "/_matrix/media_proxy/unstable/";
 
     // HS config
     private final HomeServerConnectionConfig mHsConfig;
@@ -68,7 +68,7 @@ public class ContentManager {
     public void configureAntiVirusScanner(boolean isEnabled) {
         mIsAvScannerEnabled = isEnabled;
         if (isEnabled) {
-            mDownloadUrlPrefix = mHsConfig.getAntiVirusServerUri().toString() + URI_PREFIX_MEDIA_PROXY_API;
+            mDownloadUrlPrefix = mHsConfig.getAntiVirusServerUri().toString() + "/" + RestClient.URI_API_PREFIX_PATH_MEDIA_PROXY_UNSTABLE;
         } else {
             mDownloadUrlPrefix = mHsConfig.getHomeserverUri().toString() + URI_PREFIX_CONTENT_API;
         }
@@ -120,7 +120,7 @@ public class ContentManager {
      * @param contentUrl the content URL (in the form of "mxc://...").
      * @return true if contentUrl is valid.
      */
-    public boolean isValidMatrixContentUrl(String contentUrl) {
+    public static boolean isValidMatrixContentUrl(String contentUrl) {
         return (null != contentUrl && contentUrl.startsWith(MATRIX_CONTENT_URI_SCHEME));
     }
 


### PR DESCRIPTION
- Enable/Disable the anti-virus scanner at ContentManager level
- Add an optional anti-virus uri in HomeServerConnectionConfig
- When the av scanner is enabled, a unique url is used to handle all the encrypted contents. This breaks the current download identifier model.
- We introduce a new download id model based on the media Id and the server name available in the matrix content uri.
- This download id is used to handle the cache too. A clear cache should be forced.

Matrix content scanner details: https://github.com/matrix-org/matrix-content-scanner/blob/master/README.md