### PR TITLE
Prefer message text instead of subject

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
 Bugfix:
  - Prevent crash on KitKat
  - Prevent leaking of filenames in uploads to E2EE rooms
+ - Prefer message text instead of subject
 
 API Change:
  - New API: add device_id param to LoginRestClient.loginWithUser()

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomMediaMessage.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomMediaMessage.java
@@ -768,27 +768,23 @@ public class RoomMediaMessage implements Parcelable {
             // chrome adds many items when sharing an web page link
             // so, test first the type
             if (TextUtils.equals(intent.getType(), ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-                String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+                String message = intent.getStringExtra(Intent.EXTRA_TEXT);
 
-                if (null == text) {
+                if (null == message) {
                     CharSequence sequence = intent.getCharSequenceExtra(Intent.EXTRA_TEXT);
                     if (null != sequence) {
-                        text = sequence.toString();
+                        message = sequence.toString();
                     }
                 }
 
                 String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
 
-                String message = "";
-
                 if (!TextUtils.isEmpty(subject)) {
-                    message = subject;
-                }
-
-                if (TextUtils.isEmpty(message)) {
-                    message = text;
-                } else if (!TextUtils.isEmpty(text) && android.util.Patterns.WEB_URL.matcher(text).matches()) {
-                    message += "\n" + text;
+                    if (TextUtils.isEmpty(message)) {
+                        message = subject;
+                    } else if (android.util.Patterns.WEB_URL.matcher(message).matches()) {
+                        message = subject + "\n" + message;
+                    }
                 }
 
                 if (!TextUtils.isEmpty(message)) {


### PR DESCRIPTION
This is a quick and untested patch to fix issue #284.

I have attempted to retain the behaviour of reverting to `subject\ntext` when `text` is a URL.