### PR TITLE
only pass filename to server if non-encrypted room to prevent name leak

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bugfix:
  - Prevent crash on KitKat
+ - Prevent leaking of filenames in uploads to E2EE rooms
 
 API Change:
  - New API: add device_id param to LoginRestClient.loginWithUser()

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomMediaMessagesSender.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomMediaMessagesSender.java
@@ -628,6 +628,8 @@ class RoomMediaMessagesSender {
                 final Uri encryptedUri;
                 InputStream stream;
 
+                String filename = null;
+
                 try {
                     stream = new FileInputStream(new File(uri.getPath()));
                     if (mRoom.isEncrypted() && mDataHandler.isCryptoEnabled() && (null != stream)) {
@@ -656,6 +658,8 @@ class RoomMediaMessagesSender {
                             return;
                         }
                     } else {
+                        // Only pass filename string to server in non-encrypted rooms to prevent leaking filename
+                        filename = mediaMessage.isThumbnailLocalContent() ? ("thumb" + message.body) : message.body;
                         encryptionResult = null;
                         encryptedUri = null;
                     }
@@ -666,7 +670,7 @@ class RoomMediaMessagesSender {
 
                 mDataHandler.updateEventState(roomMediaMessage.getEvent(), Event.SentState.SENDING);
 
-                mediasCache.uploadContent(stream, mediaMessage.isThumbnailLocalContent() ? ("thumb" + message.body) : message.body, mimeType, url,
+                mediasCache.uploadContent(stream, filename, mimeType, url,
                         new MXMediaUploadListener() {
                     @Override
                     public void onUploadStart(final String uploadId) {


### PR DESCRIPTION
### Fixes https://github.com/vector-im/riot-android/issues/2367

![image](https://user-images.githubusercontent.com/2403652/41465850-b96e02c0-7097-11e8-9410-79915d9cd9b4.png)

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>
