### PR TITLE
bug fix on av scanner support

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
@@ -763,9 +763,11 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
                 // if some medias are not found
                 // do not try to reload them until the next application launch.
-                // TODO check what happen with the commun url for encrypted content
-                synchronized (mUnreachableUrls) {
-                    mUnreachableUrls.add(mUrl);
+                // Ignore here the case where the media is encrypted and the av scanner is enabled because the same url is used for all encrypted media.
+                if (null == mEncryptedFileInfo || !mIsAvScannerEnabled) {
+                    synchronized (mUnreachableUrls) {
+                        mUnreachableUrls.add(mUrl);
+                    }
                 }
             }
 
@@ -777,9 +779,11 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
                 // if some medias are not found
                 // do not try to reload them until the next application launch.
-                // TODO check what happen with the commun url for encrypted content
-                synchronized (mUnreachableUrls) {
-                    mUnreachableUrls.add(mUrl);
+                // Ignore here the case where the media is encrypted and the av scanner is enabled because the same url is used for all encrypted media.
+                if (null == mEncryptedFileInfo || !mIsAvScannerEnabled) {
+                    synchronized (mUnreachableUrls) {
+                        mUnreachableUrls.add(mUrl);
+                    }
                 }
             }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
@@ -763,7 +763,8 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
                 // if some medias are not found
                 // do not try to reload them until the next application launch.
-                // Ignore here the case where the media is encrypted and the av scanner is enabled because the same url is used for all encrypted media.
+                // Apply this only for unencrypted media when the av scanner is enabled
+                // because the same url is used for all encrypted media.
                 if (null == mEncryptedFileInfo || !mIsAvScannerEnabled) {
                     synchronized (mUnreachableUrls) {
                         mUnreachableUrls.add(mUrl);
@@ -779,7 +780,8 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
                 // if some medias are not found
                 // do not try to reload them until the next application launch.
-                // Ignore here the case where the media is encrypted and the av scanner is enabled because the same url is used for all encrypted media.
+                // Apply this only for unencrypted media when the av scanner is enabled
+                // because the same url is used for all encrypted media.
                 if (null == mEncryptedFileInfo || !mIsAvScannerEnabled) {
                     synchronized (mUnreachableUrls) {
                         mUnreachableUrls.add(mUrl);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediaDownloadWorkerTask.java
@@ -761,11 +761,12 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
                 //Log.d(LOG_TAG, "MediaWorkerTask " + mUrl + " does not exist");
                 Log.d(LOG_TAG, "MediaWorkerTask an url does not exist");
 
-                // if some medias are not found
+                // If some medias are not found,
                 // do not try to reload them until the next application launch.
-                // Apply this only for unencrypted media when the av scanner is enabled
-                // because the same url is used for all encrypted media.
-                if (null == mEncryptedFileInfo || !mIsAvScannerEnabled) {
+                // We mark this url as unreachable.
+                // We can do this only if the av scanner is disabled or if the media is unencrypted,
+                // (because the same url is used for all encrypted media when the av scanner is enabled).
+                if (!mIsAvScannerEnabled || null == mEncryptedFileInfo) {
                     synchronized (mUnreachableUrls) {
                         mUnreachableUrls.add(mUrl);
                     }
@@ -780,9 +781,10 @@ class MXMediaDownloadWorkerTask extends AsyncTask<Integer, IMXMediaDownloadListe
 
                 // if some medias are not found
                 // do not try to reload them until the next application launch.
-                // Apply this only for unencrypted media when the av scanner is enabled
-                // because the same url is used for all encrypted media.
-                if (null == mEncryptedFileInfo || !mIsAvScannerEnabled) {
+                // We mark this url as unreachable.
+                // We can do this only if the av scanner is disabled or if the media is unencrypted,
+                // (because the same url is used for all encrypted media when the av scanner is enabled).
+                if (!mIsAvScannerEnabled || null == mEncryptedFileInfo) {
                     synchronized (mUnreachableUrls) {
                         mUnreachableUrls.add(mUrl);
                     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -1101,10 +1101,10 @@ public class MXMediasCache {
             downloadId += "_apply_orientation";
         }
 
-        final String fDownloadableUrl = downloadId;
+        final String fDownloadId = downloadId;
 
         if (null != imageView) {
-            imageView.setTag(fDownloadableUrl);
+            imageView.setTag(fDownloadId);
         }
 
         // if the mime type is not provided, assume it is a jpeg file
@@ -1117,7 +1117,7 @@ public class MXMediasCache {
                     @Override
                     public void onSuccess(Bitmap bitmap) {
                         if (null != imageView) {
-                            if (TextUtils.equals(fDownloadableUrl, (String) imageView.getTag())) {
+                            if (TextUtils.equals(fDownloadId, (String) imageView.getTag())) {
                                 // display it
                                 imageView.setImageBitmap((null != bitmap) ? bitmap : defaultBitmap);
                             }


### PR DESCRIPTION
- MXMediaCache: fix the wrong imageView tag used to download asynchronously an image
- MXMediaDownloadWorkerTask: fix the download of an encrypted media
- MXMediaDownloadWorkerTask: Do not blacklist the url on error when the media is encrypted and the av scanner is enabled because the same url is used for all encrypted media.