### PR TITLE
Add support for the scanning and downloading of unencrypted thumbnails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Improvements:
  - MXCrypto: Encrypt the messages for invited members according to the history visibility (if the option is enabled in MXCryptoConfig).
  - Upgrade olm-sdk.aar from version 2.2.2 to version 2.3.0
  - Add a method to MediaScanRestClient to get the public key of the media scanner server
+ - Add support for the scanning and downloading of unencrypted thumbnails
 
 Bugfix:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
@@ -35,6 +35,8 @@ public class ContentManager {
 
     public static final String URI_PREFIX_CONTENT_API = "/_matrix/media/v1/";
 
+    public static final String MATRIX_CONTENT_IDENTICON_PREFIX = "identicon/";
+
     // HS config
     private final HomeServerConnectionConfig mHsConfig;
 
@@ -109,7 +111,7 @@ public class ContentManager {
                 Log.e(LOG_TAG, "## getIdenticonURL() : java.net.URLEncoder.encode failed " + e.getMessage());
             }
 
-            return ContentManager.MATRIX_CONTENT_URI_SCHEME + "identicon/" + urlEncodedUser;
+            return ContentManager.MATRIX_CONTENT_URI_SCHEME + MATRIX_CONTENT_IDENTICON_PREFIX + urlEncodedUser;
         }
 
         return null;
@@ -205,13 +207,13 @@ public class ContentManager {
 
             // Build the thumbnail url.
             String url;
-            // Caution: identicon has no thumbnail path
-            if (mediaServerAndId.indexOf("identicon") < 0) {
-                // Use the current download url prefix to take into account a potential antivirus scanner
-                url = mDownloadUrlPrefix + "thumbnail/";
-            } else {
+            // Caution: identicon has no thumbnail path.
+            if (mediaServerAndId.startsWith(MATRIX_CONTENT_IDENTICON_PREFIX)) {
                 // identicon url still go to the media repo since they don’t need virus scanning
                 url = mHsConfig.getHomeserverUri().toString() + URI_PREFIX_CONTENT_API;
+            } else {
+                // Use the current download url prefix to take into account a potential antivirus scanner
+                url = mDownloadUrlPrefix + "thumbnail/";
             }
 
             url += mediaServerAndId;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/ContentManager.java
@@ -203,12 +203,15 @@ public class ContentManager {
                 mediaServerAndId = mediaServerAndId.substring(0, mediaServerAndId.length() - "#auto".length());
             }
 
-            // Thumbnail url still go to the media repo since they don’t need virus scanning
-            String url = mHsConfig.getHomeserverUri().toString() + URI_PREFIX_CONTENT_API;
-
-            // identicon server has no thumbnail path
+            // Build the thumbnail url.
+            String url;
+            // Caution: identicon has no thumbnail path
             if (mediaServerAndId.indexOf("identicon") < 0) {
-                url += "thumbnail/";
+                // Use the current download url prefix to take into account a potential antivirus scanner
+                url = mDownloadUrlPrefix + "thumbnail/";
+            } else {
+                // identicon url still go to the media repo since they don’t need virus scanning
+                url = mHsConfig.getHomeserverUri().toString() + URI_PREFIX_CONTENT_API;
             }
 
             url += mediaServerAndId;


### PR DESCRIPTION
Implement matrix-org/matrix-content-scanner#8 on client side