### PR TITLE
Use same TxId when resending an event, to avoid event duplication

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Improvements:
 Bugfix:
  - Send Access Token as a header instead of a url parameter to upload content (#311)
  - Add API CallSoundsManager.startRingingSilently() to fix issue when incoming call sound is disable (vector-im/riot-android#2417)
+ - Use same TxId when resending an event. The eventId is used as a TxId. (vector-im/riot-android#1997)
 
 API Change:
  - Parameter historyVisibility removed from MxSession.createRoom(). It had no effect.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -2422,7 +2422,7 @@ public class Room {
 
                             // sending in progress
                             mDataHandler.updateEventState(event, Event.SentState.SENDING);
-                            mDataHandler.getDataRetriever().getRoomsRestClient().sendEventToRoom(event.originServerTs + "", getRoomId(),
+                            mDataHandler.getDataRetriever().getRoomsRestClient().sendEventToRoom(event.eventId, getRoomId(),
                                     encryptEventContentResult.mEventType, encryptEventContentResult.mEventContent.getAsJsonObject(), localCB);
                         }
 
@@ -2467,10 +2467,10 @@ public class Room {
 
             if (Event.EVENT_TYPE_MESSAGE.equals(event.getType())) {
                 mDataHandler.getDataRetriever().getRoomsRestClient()
-                        .sendMessage(event.originServerTs + "", getRoomId(), JsonUtils.toMessage(event.getContent()), localCB);
+                        .sendMessage(event.eventId, getRoomId(), JsonUtils.toMessage(event.getContent()), localCB);
             } else {
                 mDataHandler.getDataRetriever().getRoomsRestClient()
-                        .sendEventToRoom(event.originServerTs + "", getRoomId(), event.getType(), event.getContentAsJsonObject(), localCB);
+                        .sendEventToRoom(event.eventId, getRoomId(), event.getType(), event.getContentAsJsonObject(), localCB);
             }
         }
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -53,6 +53,7 @@ import org.matrix.androidsdk.rest.client.AccountDataRestClient;
 import org.matrix.androidsdk.rest.client.RoomsRestClient;
 import org.matrix.androidsdk.rest.client.UrlPostTask;
 import org.matrix.androidsdk.rest.model.BannedUser;
+import org.matrix.androidsdk.rest.model.CreatedEvent;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.MatrixError;
 import org.matrix.androidsdk.rest.model.PowerLevels;
@@ -2309,9 +2310,9 @@ public class Room {
 
         final String prevEventId = event.eventId;
 
-        final ApiCallback<Event> localCB = new ApiCallback<Event>() {
+        final ApiCallback<CreatedEvent> localCB = new ApiCallback<CreatedEvent>() {
             @Override
-            public void onSuccess(final Event serverResponseEvent) {
+            public void onSuccess(final CreatedEvent createdEvent) {
                 if (null != getStore()) {
                     // remove the tmp event
                     getStore().deleteEvent(event);
@@ -2321,12 +2322,12 @@ public class Room {
                 boolean isReadMarkerUpdated = TextUtils.equals(getReadMarkerEventId(), event.eventId);
 
                 // update the event with the server response
-                event.eventId = serverResponseEvent.eventId;
+                event.eventId = createdEvent.eventId;
                 event.originServerTs = System.currentTimeMillis();
                 mDataHandler.updateEventState(event, Event.SentState.SENT);
 
                 // the message echo is not yet echoed
-                if ((null != getStore()) && !getStore().doesEventExist(serverResponseEvent.eventId, getRoomId())) {
+                if (null != getStore() && !getStore().doesEventExist(createdEvent.eventId, getRoomId())) {
                     getStore().storeLiveRoomEvent(event);
                 }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -1342,6 +1342,9 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
         final Message message = JsonUtils.toMessage(event.getContent());
         final RoomMediaMessage roomMediaMessage = new RoomMediaMessage(new Event(message, mSession.getMyUserId(), mRoom.getRoomId()));
 
+        // Restore the previous eventId, to use the same TransactionId when sending again the event
+        roomMediaMessage.getEvent().eventId = event.eventId;
+
         if (message instanceof MediaMessage) {
             sendMediaMessage(roomMediaMessage);
         } else {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/RoomsApi.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/RoomsApi.java
@@ -24,6 +24,7 @@ import org.matrix.androidsdk.data.RoomState;
 import org.matrix.androidsdk.rest.model.BannedUser;
 import org.matrix.androidsdk.rest.model.CreateRoomParams;
 import org.matrix.androidsdk.rest.model.CreateRoomResponse;
+import org.matrix.androidsdk.rest.model.CreatedEvent;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.EventContext;
 import org.matrix.androidsdk.rest.model.PowerLevels;
@@ -53,7 +54,7 @@ import retrofit2.http.Query;
 public interface RoomsApi {
 
     /**
-     * Send an event about a room.
+     * Send an event to a room.
      *
      * @param txId      the transaction Id
      * @param roomId    the room id
@@ -61,7 +62,7 @@ public interface RoomsApi {
      * @param content   the event content
      */
     @PUT("rooms/{roomId}/send/{eventType}/{txId}")
-    Call<Event> send(@Path("txId") String txId, @Path("roomId") String roomId, @Path("eventType") String eventType, @Body JsonObject content);
+    Call<CreatedEvent> send(@Path("txId") String txId, @Path("roomId") String roomId, @Path("eventType") String eventType, @Body JsonObject content);
 
     /**
      * Send a message to the specified room.
@@ -71,7 +72,7 @@ public interface RoomsApi {
      * @param message the message
      */
     @PUT("rooms/{roomId}/send/m.room.message/{txId}")
-    Call<Event> sendMessage(@Path("txId") String txId, @Path("roomId") String roomId, @Body Message message);
+    Call<CreatedEvent> sendMessage(@Path("txId") String txId, @Path("roomId") String roomId, @Body Message message);
 
     /**
      * Set the room topic.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/RoomsRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/RoomsRestClient.java
@@ -35,6 +35,7 @@ import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.rest.model.BannedUser;
 import org.matrix.androidsdk.rest.model.CreateRoomParams;
 import org.matrix.androidsdk.rest.model.CreateRoomResponse;
+import org.matrix.androidsdk.rest.model.CreatedEvent;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.EventContext;
 import org.matrix.androidsdk.rest.model.MatrixError;
@@ -78,14 +79,14 @@ public class RoomsRestClient extends RestClient<RoomsApi> {
      * @param message       the message
      * @param callback      the callback containing the created event if successful
      */
-    public void sendMessage(final String transactionId, final String roomId, final Message message, final ApiCallback<Event> callback) {
+    public void sendMessage(final String transactionId, final String roomId, final Message message, final ApiCallback<CreatedEvent> callback) {
         // privacy
         // final String description = "SendMessage : roomId " + roomId + " - message " + message.body;
         final String description = "SendMessage : roomId " + roomId;
 
         // the messages have their dedicated method in MXSession to be resent if there is no available network
         mApi.sendMessage(transactionId, roomId, message)
-                .enqueue(new RestAdapterCallback<Event>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
+                .enqueue(new RestAdapterCallback<CreatedEvent>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
             @Override
             public void onRetry() {
                 sendMessage(transactionId, roomId, message, callback);
@@ -106,7 +107,7 @@ public class RoomsRestClient extends RestClient<RoomsApi> {
                                 final String roomId,
                                 final String eventType,
                                 final JsonObject content,
-                                final ApiCallback<Event> callback) {
+                                final ApiCallback<CreatedEvent> callback) {
         // privacy
         //final String description = "sendEvent : roomId " + roomId + " - eventType " + eventType + " content " + content;
         final String description = "sendEvent : roomId " + roomId + " - eventType " + eventType;
@@ -115,7 +116,7 @@ public class RoomsRestClient extends RestClient<RoomsApi> {
         // it might trigger weird behaviour on flaggy networks
         if (!TextUtils.equals(eventType, Event.EVENT_TYPE_CALL_INVITE)) {
             mApi.send(transactionId, roomId, eventType, content)
-                    .enqueue(new RestAdapterCallback<Event>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
+                    .enqueue(new RestAdapterCallback<CreatedEvent>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
                 @Override
                 public void onRetry() {
                     sendEventToRoom(transactionId, roomId, eventType, content, callback);
@@ -123,7 +124,7 @@ public class RoomsRestClient extends RestClient<RoomsApi> {
             }));
         } else {
             mApi.send(transactionId, roomId, eventType, content)
-                    .enqueue(new RestAdapterCallback<Event>(description, mUnsentEventsManager, callback, null));
+                    .enqueue(new RestAdapterCallback<CreatedEvent>(description, mUnsentEventsManager, callback, null));
         }
     }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/CreatedEvent.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/CreatedEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk.rest.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class CreatedEvent {
+    @SerializedName("event_id")
+    public String eventId;
+}


### PR DESCRIPTION
The eventId is used as a TxId.

Fixes vector-im/riot-android#1997