### PR TITLE
Bug Fix - Do not remove from the direct chat list the room id of the left rooms.

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
@@ -2695,8 +2695,8 @@ public class MXDataHandler implements IMXEventListener {
         if (null != listOfList) {
             for (List<String> list : listOfList) {
                 for (String roomId : list) {
-                    // test if the room is defined once and exists
-                    if ((directChatRoomIdsList.indexOf(roomId) < 0) && (null != store.getRoom(roomId))) {
+                    // test if the room is defined once
+                    if ((directChatRoomIdsList.indexOf(roomId) < 0)) {
                         directChatRoomIdsList.add(roomId);
                     }
                 }


### PR DESCRIPTION
These rooms must appear as a direct chats if the user joined them again.

With the previous code, a direct chat may appear as a normal room in the following use case:
A start chat with B for the first time
B receives an invite displayed like a direct chat OK
B joins the discussion
B leaves the discussion
B logs out, and logs in
A invites again B in this room
B joins the room, it is displayed like a normal room NOK
Note: this room is displayed like a direct chat after a clear cache