### PR TITLE
Allow '@' in room alias

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  -
 
 Bugfix:
- -
+ - Room aliases including the '@' character are now recognized as valid (vector-im/riot-android#2079)
 
 API Change:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -180,7 +180,7 @@ public class MXSession {
     public static final Pattern PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = Pattern.compile(MATRIX_USER_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room aliases in a string.
-    public static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    public static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
     public static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room ids in a string.


### PR DESCRIPTION
Allows the '@' character in the room alias. Unfortunately, the Matrix spec doesn't define allowed characters or grammar for room aliases, but '@' sure seems to be valid.

Fixes: https://github.com/vector-im/riot-android/issues/2079
Matrix spec: https://matrix.org/docs/spec/appendices.html#common-identifier-format