### PR TITLE
Do not nullify room name or topic in case it is empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bugfix:
  - Room aliases including the '@' character are now recognized as valid (vector-im/riot-android#2079)
+ - Room name and topic can be now set back to empty
 
 API Change:
  - Remove PieFractionView class from the Matrix SDK. This class is now in Riot sources (#336)

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -830,13 +830,11 @@ public class Room {
      * @param aRoomName the new name
      * @param callback  the async callback
      */
-    public void updateName(String aRoomName, final ApiCallback<Void> callback) {
-        final String fRoomName = TextUtils.isEmpty(aRoomName) ? null : aRoomName;
-
-        mDataHandler.getDataRetriever().getRoomsRestClient().updateRoomName(getRoomId(), fRoomName, new RoomInfoUpdateCallback<Void>(callback) {
+    public void updateName(final String aRoomName, final ApiCallback<Void> callback) {
+        mDataHandler.getDataRetriever().getRoomsRestClient().updateRoomName(getRoomId(), aRoomName, new RoomInfoUpdateCallback<Void>(callback) {
             @Override
             public void onSuccess(Void info) {
-                getState().name = fRoomName;
+                getState().name = aRoomName;
                 super.onSuccess(info);
             }
         });
@@ -849,12 +847,10 @@ public class Room {
      * @param callback the async callback
      */
     public void updateTopic(final String aTopic, final ApiCallback<Void> callback) {
-        final String fTopic = TextUtils.isEmpty(aTopic) ? null : aTopic;
-
-        mDataHandler.getDataRetriever().getRoomsRestClient().updateTopic(getRoomId(), fTopic, new RoomInfoUpdateCallback<Void>(callback) {
+        mDataHandler.getDataRetriever().getRoomsRestClient().updateTopic(getRoomId(), aTopic, new RoomInfoUpdateCallback<Void>(callback) {
             @Override
             public void onSuccess(Void info) {
-                getState().topic = fTopic;
+                getState().topic = aTopic;
                 super.onSuccess(info);
             }
         });


### PR DESCRIPTION
Hi,

I was looking at https://github.com/vector-im/riot-android/issues/2345
The name is indeed missing from the API request. This is caused by Gson, which, by default, ignores null objects and does not serialize them. The name String is null in this case. Gson null object serialization can be enabled here, using the last parameter in the superclass constructor:
https://github.com/matrix-org/matrix-android-sdk/blob/develop/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/RoomsRestClient.java#L71
This, however, doesn't fix the issue as the server complains the name is not of the String type. The actual JSON sent is `{"name":null}`.

I think the correct solution would be to skip nullifying the name String. The JSON is then `{"name":""}` and the room is assigned the original, default name. I was looking at other usages of the name String so this change doesn't break anything, but all usages seem to be checked with `TextUtils.isEmpty()` anyway, so it should be safe.

There is the same story with room topic.

Fixes https://github.com/vector-im/riot-android/issues/2345
Signed-off-by: Zbigniew Brzeziński brzezinski.z@gmx.com