### PR TITLE
Feature/issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ API Change:
  - Remove PieFractionView class from the Matrix SDK. This class is now in Riot sources (#336)
  - MXMediasCache.createTmpMediaFile() methods are rename to createTmpDecryptedMediaFile()
  - MXMediasCache.clearTmpCache() method is rename to clearTmpDecryptedMediaCache()
+ - Add MXMediasCache.moveToShareFolder() to move a tmp decrypted file to another folder to prevent deletion during sharing. New API MXMediasCache.clearShareDecryptedMediaCache() can be called when the application is resumed. (vector-im/riot-android#2530)
 
 Translations:
  -

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@ Bugfix:
 
 API Change:
  - Remove PieFractionView class from the Matrix SDK. This class is now in Riot sources (#336)
- - MXMediasCache.createTmpMediaFile() methods are rename to createTmpDecryptedMediaFile()
- - MXMediasCache.clearTmpCache() method is rename to clearTmpDecryptedMediaCache()
+ - MXMediasCache.createTmpMediaFile() methods are renamed to createTmpDecryptedMediaFile()
+ - MXMediasCache.clearTmpCache() method is renamed to clearTmpDecryptedMediaCache()
  - Add MXMediasCache.moveToShareFolder() to move a tmp decrypted file to another folder to prevent deletion during sharing. New API MXMediasCache.clearShareDecryptedMediaCache() can be called when the application is resumed. (vector-im/riot-android#2530)
 
 Translations:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Bugfix:
 
 API Change:
  - Remove PieFractionView class from the Matrix SDK. This class is now in Riot sources (#336)
+ - MXMediasCache.createTmpMediaFile() methods are rename to createTmpDecryptedMediaFile()
+ - MXMediasCache.clearTmpCache() method is rename to clearTmpDecryptedMediaCache()
 
 Translations:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -1069,7 +1069,7 @@ public class MXSession {
         }
 
         if (null != getMediasCache()) {
-            getMediasCache().clearTmpCache();
+            getMediasCache().clearTmpDecryptedMediaCache();
         }
 
         if (null != mGroupsManager) {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -1112,6 +1112,10 @@ public class MXSession {
             Log.d(LOG_TAG, "## resumeEventStream() : cancel bg sync");
         }
 
+        if (null != getMediasCache()) {
+            getMediasCache().clearShareDecryptedMediaCache();
+        }
+
         if (null != mGroupsManager) {
             mGroupsManager.onSessionResumed();
         }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXEncryptedAttachments.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXEncryptedAttachments.java
@@ -146,7 +146,7 @@ public class MXEncryptedAttachments implements Serializable {
     /**
      * Decrypt an attachment
      *
-     * @param attachmentStream  the attahcment stream
+     * @param attachmentStream  the attachment stream
      * @param encryptedFileInfo the encryption file info
      * @return the decrypted attachment stream
      */

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -487,6 +487,9 @@ public class MXMediasCache {
                             while ((len = fis.read(buf)) != -1) {
                                 fos.write(buf, 0, len);
                             }
+
+                            fis.close();
+                            fos.close();
                         } catch (Exception e) {
                             Log.e(LOG_TAG, "## createTmpMediaFile() failed " + e.getMessage(), e);
                         }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -347,7 +347,7 @@ public class MXMediasCache {
     }
 
     /**
-     * Return the cache file name for a media defined by its URL and its mimetype.
+     * Return the cache file name for a media defined by its URL and its mime type.
      *
      * @param url      the media URL
      * @param width    the media width

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -76,6 +76,7 @@ public class MXMediasCache {
     private static final String MXMEDIA_STORE_IMAGES_FOLDER = "Images";
     private static final String MXMEDIA_STORE_OTHERS_FOLDER = "Others";
     private static final String MXMEDIA_STORE_TMP_FOLDER = "tmp";
+    private static final String MXMEDIA_STORE_SHARE_FOLDER = "share";
 
     /**
      * The content manager
@@ -92,6 +93,9 @@ public class MXMediasCache {
 
     // This folder will contain decrypted media files
     private File mTmpFolderFile;
+
+    // This folder will contain decrypted media files, for file sharing
+    private File mShareFolderFile;
 
     // track the network updates
     private final NetworkConnectivityReceiver mNetworkConnectivityReceiver;
@@ -142,6 +146,13 @@ public class MXMediasCache {
             ContentUtils.deleteDirectory(mTmpFolderFile);
         }
         mTmpFolderFile.mkdirs();
+
+        mShareFolderFile = new File(mMediasFolderFile, MXMEDIA_STORE_SHARE_FOLDER);
+
+        if (mShareFolderFile.exists()) {
+            ContentUtils.deleteDirectory(mShareFolderFile);
+        }
+        mShareFolderFile.mkdirs();
 
         mThumbnailsFolderFile = new File(mediaBaseFolderFile, MXMEDIA_STORE_MEMBER_THUMBNAILS_FOLDER);
 
@@ -512,12 +523,55 @@ public class MXMediasCache {
      * Clear the temporary decrypted media cache folder
      */
     public void clearTmpDecryptedMediaCache() {
+        Log.d(LOG_TAG, "clearTmpDecryptedMediaCache()");
+
         if (mTmpFolderFile.exists()) {
             ContentUtils.deleteDirectory(mTmpFolderFile);
         }
 
         if (!mTmpFolderFile.exists()) {
             mTmpFolderFile.mkdirs();
+        }
+    }
+
+    /**
+     * Move a decrypted media file to the /share folder, to avoid this file to be deleted if in the /tmp folder
+     *
+     * @param fileToMove The file to move
+     * @return The copied file in the Share folder location
+     */
+    public File moveToShareFolder(final File fileToMove,
+                                  final String filename) {
+        File dstFile = new File(mShareFolderFile, filename);
+
+        if (dstFile.exists()) {
+            if (!dstFile.delete()) {
+                Log.w(LOG_TAG, "Unable to delete file");
+            }
+        }
+
+        if (!fileToMove.renameTo(dstFile)) {
+            Log.w(LOG_TAG, "Unable to rename file");
+
+            // Return the original file
+            return fileToMove;
+        }
+
+        return dstFile;
+    }
+
+    /**
+     * Clear the temporary shared decrypted media cache folder
+     */
+    public void clearShareDecryptedMediaCache() {
+        Log.d(LOG_TAG, "clearShareDecryptedMediaCache()");
+
+        if (mShareFolderFile.exists()) {
+            ContentUtils.deleteDirectory(mShareFolderFile);
+        }
+
+        if (!mShareFolderFile.exists()) {
+            mShareFolderFile.mkdirs();
         }
     }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -538,6 +538,7 @@ public class MXMediasCache {
      * Move a decrypted media file to the /share folder, to avoid this file to be deleted if in the /tmp folder
      *
      * @param fileToMove The file to move
+     * @param filename   the filename, without path
      * @return The copied file in the Share folder location
      */
     public File moveToShareFolder(final File fileToMove,

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/db/MXMediasCache.java
@@ -90,6 +90,7 @@ public class MXMediasCache {
     private File mOthersFolderFile;
     private File mThumbnailsFolderFile;
 
+    // This folder will contain decrypted media files
     private File mTmpFolderFile;
 
     // track the network updates
@@ -423,20 +424,20 @@ public class MXMediasCache {
     }
 
     /**
-     * Create a temporary copy of a media.
-     * It must be released when it is not anymore used with clearTmpCache().
+     * Create a temporary decrypted copy of a media.
+     * It must be released when it is not used anymore with clearTmpDecryptedMediaCache().
      *
-     * @param url               the url
-     * @param mimeType          the mimetype
+     * @param url               the media url
+     * @param mimeType          the media mime type
      * @param encryptedFileInfo the encryption information
      * @param callback          the asynchronous callback
      * @return true if the file is cached
      */
-    public boolean createTmpMediaFile(String url,
-                                      String mimeType,
-                                      EncryptedFileInfo encryptedFileInfo,
-                                      ApiCallback<File> callback) {
-        return createTmpMediaFile(url,
+    public boolean createTmpDecryptedMediaFile(String url,
+                                               String mimeType,
+                                               EncryptedFileInfo encryptedFileInfo,
+                                               ApiCallback<File> callback) {
+        return createTmpDecryptedMediaFile(url,
                 -1,
                 -1,
                 mimeType,
@@ -445,8 +446,8 @@ public class MXMediasCache {
     }
 
     /**
-     * Create a temporary copy of a media.
-     * It must be released when it is not anymore used with clearTmpCache().
+     * Create a temporary decrypted copy of a media.
+     * It must be released when it is not used anymore with clearTmpDecryptedMediaCache().
      *
      * @param url               the media URL
      * @param width             the media width
@@ -456,12 +457,12 @@ public class MXMediasCache {
      * @param callback          the asynchronous callback
      * @return true if the file is cached
      */
-    public boolean createTmpMediaFile(String url,
-                                      int width,
-                                      int height,
-                                      String mimeType,
-                                      final EncryptedFileInfo encryptedFileInfo,
-                                      final ApiCallback<File> callback) {
+    public boolean createTmpDecryptedMediaFile(String url,
+                                               int width,
+                                               int height,
+                                               String mimeType,
+                                               final EncryptedFileInfo encryptedFileInfo,
+                                               final ApiCallback<File> callback) {
         final File file = mediaCacheFile(url, width, height, mimeType);
 
         if (null != file) {
@@ -470,7 +471,7 @@ public class MXMediasCache {
                 public void run() {
                     final File tmpFile = new File(mTmpFolderFile, file.getName());
 
-                    // create it if it does not exist
+                    // create it only if it does not exist yet
                     if (!tmpFile.exists()) {
                         try {
                             InputStream fis = new FileInputStream(file);
@@ -491,7 +492,7 @@ public class MXMediasCache {
                             fis.close();
                             fos.close();
                         } catch (Exception e) {
-                            Log.e(LOG_TAG, "## createTmpMediaFile() failed " + e.getMessage(), e);
+                            Log.e(LOG_TAG, "## createTmpDecryptedMediaFile() failed " + e.getMessage(), e);
                         }
                     }
 
@@ -508,9 +509,9 @@ public class MXMediasCache {
     }
 
     /**
-     * Clear the temporary cache file
+     * Clear the temporary decrypted media cache folder
      */
-    public void clearTmpCache() {
+    public void clearTmpDecryptedMediaCache() {
         if (mTmpFolderFile.exists()) {
             ContentUtils.deleteDirectory(mTmpFolderFile);
         }


### PR DESCRIPTION
 - MXMediasCache.createTmpMediaFile() methods are renamed to createTmpDecryptedMediaFile()
 - MXMediasCache.clearTmpCache() method is renamed to clearTmpDecryptedMediaCache()
 - Add MXMediasCache.moveToShareFolder() to move a tmp decrypted file to another folder to prevent deletion during sharing. New API MXMediasCache.clearShareDecryptedMediaCache() can be called when the application is resumed. (vector-im/riot-android#2530)