### PR TITLE
Add ability to use filter from server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Translations:
  -
 
 Others:
- - MXSession.setUseDataSaveMode(boolean) is now deprecated. Handle filter-id lookup in your app and use MXSession.setSyncFilter(String)
+ - MXSession.setUseDataSaveMode(boolean) is now deprecated. Handle filter-id lookup in your app and use MXSession.setSyncFilterOrFilterId(String)
 
 Build:
  -

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes to Matrix Android SDK in 0.9.8 (2018-XX-XX)
 
 Features:
  - Manage server_notices tag and server quota notices (vector-im/riot-android#2440)
+ - Add handling of filters (#345)
 
 Improvements:
  -
@@ -21,7 +22,7 @@ Translations:
  -
 
 Others:
- -
+ - MXSession.setUseDataSaveMode(boolean) is now deprecated. Handle filter-id lookup in your app and use MXSession.setSyncFilter(String)
 
 Build:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -169,7 +169,7 @@ public class MXSession {
     // so, mEventsThread.start might be not ready
     private boolean mIsBgCatchupPending = false;
 
-    private String mFilterId;
+    private String mFilterOrFilterId;
 
     // the groups manager
     private GroupsManager mGroupsManager;
@@ -888,7 +888,7 @@ public class MXSession {
             final EventsThreadListener fEventsListener = (null == anEventsListener) ? new DefaultEventsThreadListener(mDataHandler) : anEventsListener;
 
             mEventsThread = new EventsThread(mAppContent, mEventsRestClient, fEventsListener, initialToken);
-            mEventsThread.setFilter(mFilterId);
+            mEventsThread.setFilterOrFilterId(mFilterOrFilterId);
             mEventsThread.setMetricsListener(mMetricsListener);
             mEventsThread.setNetworkConnectivityReceiver(networkConnectivityReceiver);
             mEventsThread.setIsOnline(mIsOnline);
@@ -1007,7 +1007,7 @@ public class MXSession {
     }
 
      /**
-     * Update the data save mode. Deprecated by setSyncFilter()
+     * Update the data save mode. Deprecated by setSyncFilterOrFilterId()
      *
      * @param enabled true to enable the data save mode
      */
@@ -1016,28 +1016,28 @@ public class MXSession {
         if (enabled) {
             Log.d(LOG_TAG, "Enable DataSyncMode # " + FilterBody.getDataSaveModeFilterBody());
             // enable the filter in JSON representation so do not block sync until the filter response is there
-            setSyncFilter(FilterBody.getDataSaveModeFilterBody().toJSONString());
+            setSyncFilterOrFilterId(FilterBody.getDataSaveModeFilterBody().toJSONString());
             mFilterRestClient.uploadFilter(getMyUserId(), FilterBody.getDataSaveModeFilterBody(), new SimpleApiCallback<FilterResponse>() {
                 @Override
                 public void onSuccess(FilterResponse filter) {
-                    setSyncFilter(filter.filterId);
+                    setSyncFilterOrFilterId(filter.filterId);
                 }
             });
         } else {
             Log.d(LOG_TAG, "Disable DataSyncMode");
-            setSyncFilter(null);
+            setSyncFilterOrFilterId(null);
         }
     }
 
     /**
      * Allows setting the filterId used by the EventsThread
-     * @param filterId
+     * @param filterOrFilterId the content of the filter param on sync requests
      */
-    public synchronized void setSyncFilter(String filterId) {
-        Log.d(LOG_TAG, "setSyncFilter ## " + filterId);
-        mFilterId = filterId;
+    public synchronized void setSyncFilterOrFilterId(String filterOrFilterId) {
+        Log.d(LOG_TAG, "setSyncFilterOrFilterId ## " + filterOrFilterId);
+        mFilterOrFilterId = filterOrFilterId;
         if (null != mEventsThread) {
-            mEventsThread.setFilter(filterId);
+            mEventsThread.setFilterOrFilterId(filterOrFilterId);
         }
     }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/FilterApi.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/FilterApi.java
@@ -35,7 +35,7 @@ public interface FilterApi {
      * @param body   the Json representation of a FilterBody object
      */
     @POST("user/{userId}/filter")
-    Call<FilterResponse> uploadFilter(@Path("userId") String userId, @Body Object body);
+    Call<FilterResponse> uploadFilter(@Path("userId") String userId, @Body FilterBody body);
 
     /**
      * Gets a filter with a given filterId from the homeserver

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/FilterApi.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/FilterApi.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 OpenMarket Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.matrix.androidsdk.rest.api;
+
+import org.matrix.androidsdk.rest.model.filter.FilterBody;
+import org.matrix.androidsdk.rest.model.filter.FilterResponse;
+
+import java.util.Map;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+public interface FilterApi {
+
+    /**
+     * Set some account_data for the client.
+     *
+     * @param userId   the user id
+     * @param body   the Json representation of a FilterBody object
+     */
+    @POST("user/{userId}/filter")
+    Call<FilterResponse> uploadFilter(@Path("userId") String userId, @Body Object body);
+
+    /**
+     * Gets a filter with a given filterId from the homeserver
+     *
+     * @param userId   the user id
+     * @param filterId the filterID
+     * @return Filter
+     */
+    @GET("user/{userId}/filter/{filterId}")
+    Call<FilterBody> getFilterById(@Path("userId") String userId, @Path("filterId") String filterId);
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/FilterApi.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/api/FilterApi.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2015 OpenMarket Ltd
+ * Copyright 2018 Matthias Kesler
+ * Copyright 2018 New Vector Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +30,7 @@ import retrofit2.http.Path;
 public interface FilterApi {
 
     /**
-     * Set some account_data for the client.
+     * Upload FilterBody to get a filter_id which can be used for /sync requests
      *
      * @param userId   the user id
      * @param body   the Json representation of a FilterBody object

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/FilterRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/FilterRestClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Matthias Kesler
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.matrix.androidsdk.rest.client;
 
 import com.google.gson.Gson;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/FilterRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/FilterRestClient.java
@@ -1,0 +1,61 @@
+package org.matrix.androidsdk.rest.client;
+
+import com.google.gson.Gson;
+
+import org.matrix.androidsdk.HomeServerConnectionConfig;
+import org.matrix.androidsdk.RestClient;
+import org.matrix.androidsdk.rest.api.FilterApi;
+import org.matrix.androidsdk.rest.callback.ApiCallback;
+import org.matrix.androidsdk.rest.callback.RestAdapterCallback;
+import org.matrix.androidsdk.rest.model.filter.FilterBody;
+import org.matrix.androidsdk.rest.model.filter.FilterResponse;
+
+import retrofit2.Response;
+
+public class FilterRestClient extends RestClient<FilterApi>{
+
+    /**
+     * {@inheritDoc}
+     */
+    public FilterRestClient(HomeServerConnectionConfig hsConfig) {
+        super(hsConfig, FilterApi.class, RestClient.URI_API_PREFIX_PATH_R0, false);
+    }
+
+    /**
+     * Uploads a FilterBody to homeserver
+     *
+     * @param userId   the user id
+     * @param filterBody FilterBody which should be send to server
+     * @param callback on success callback containing a String with populated filterId
+     */
+    public void uploadFilter(final String userId, final FilterBody filterBody, final ApiCallback<FilterResponse> callback) {
+        final String description = "uploadFilter userId : " + userId + " filter : " + filterBody;
+
+        mApi.uploadFilter(userId, filterBody)
+                .enqueue(new RestAdapterCallback<FilterResponse>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
+                    @Override
+                    public void onRetry() {
+                        uploadFilter(userId, filterBody, callback);
+                    }
+                }));
+    }
+
+    /**
+     * Get a user's filter by filterId
+     *
+     * @param userId   the user id
+     * @param filterId the filter id
+     * @param callback on success callback containing a User object with populated filterbody
+     */
+    public void getFilter(final String userId, final String filterId, final ApiCallback<FilterBody> callback) {
+        final String description = "getFilter userId : " + userId + " filterId : " + filterId;
+
+        mApi.getFilterById(userId, filterId)
+                .enqueue(new RestAdapterCallback<FilterBody>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
+                    @Override
+                    public void onRetry() {
+                        getFilter(userId, filterId, callback);
+                    }
+                }));
+    }
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/Filter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/Filter.java
@@ -1,0 +1,30 @@
+package org.matrix.androidsdk.rest.model.filter;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Represents "Filter" as mentioned in the SPEC
+ * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
+ */
+public class Filter implements Serializable {
+
+    public Integer limit;
+
+    public List<String> senders;
+
+    @SerializedName("not_senders")
+    public List<String> notSenders;
+
+    public List<String> types;
+
+    @SerializedName("not_types")
+    public List<String> notTypes;
+
+    public List<String> rooms;
+
+    @SerializedName("not_rooms")
+    public List<String> notRooms;
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/Filter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/Filter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Matthias Kesler
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.matrix.androidsdk.rest.model.filter;
 
 import com.google.gson.annotations.SerializedName;
@@ -9,7 +25,7 @@ import java.util.List;
  * Represents "Filter" as mentioned in the SPEC
  * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
  */
-public class Filter implements Serializable {
+public class Filter {
 
     public Integer limit;
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterBody.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterBody.java
@@ -1,0 +1,61 @@
+package org.matrix.androidsdk.rest.model.filter;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class which can be parsed to a filter json string. Used for POST and GET
+ * Have a look here for further information:
+ * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
+ */
+public class FilterBody implements Serializable {
+    public static final String LOG_TAG = FilterBody.class.getSimpleName();
+
+    @SerializedName("event_fields")
+    public List<String> eventFields;
+
+    @SerializedName("event_format")
+    public String eventFormat;
+
+    public Filter presence;
+
+    @SerializedName("account_data")
+    public Filter accountData;
+
+    public RoomFilter room;
+
+    private static FilterBody dataSaveModeFilterBody;
+
+    /**
+     *
+     * @return FilterBody which represents "{\"room\": {\"ephemeral\": {\"types\": [\"m.receipt\"]}}, \"presence\":{\"notTypes\": [\"*\"]}}"
+     */
+    public static FilterBody getDataSaveModeFilterBody() {
+        if (dataSaveModeFilterBody == null) {
+            FilterBody result = new FilterBody();
+            result.room = new RoomFilter();
+            result.room.ephemeral = new RoomEventFilter();
+            result.room.ephemeral.types = new ArrayList<>();
+            result.room.ephemeral.types.add("m.receipt");
+
+            result.presence = new Filter();
+            result.presence.notTypes = new ArrayList<>();
+            result.presence.notTypes.add("*");
+            dataSaveModeFilterBody = result;
+        }
+        return dataSaveModeFilterBody;
+    }
+
+    @Override
+    public String toString() {
+        return LOG_TAG + toJSONString();
+    }
+
+    public String toJSONString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterBody.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterBody.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Matthias Kesler
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.matrix.androidsdk.rest.model.filter;
 
 import com.google.gson.Gson;
@@ -12,7 +28,7 @@ import java.util.List;
  * Have a look here for further information:
  * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
  */
-public class FilterBody implements Serializable {
+public class FilterBody {
     public static final String LOG_TAG = FilterBody.class.getSimpleName();
 
     @SerializedName("event_fields")

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterResponse.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterResponse.java
@@ -1,0 +1,15 @@
+package org.matrix.androidsdk.rest.model.filter;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+/**
+ * Represents the body which is the response when creating a filter on the server
+ * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
+ */
+public class FilterResponse implements Serializable {
+
+    @SerializedName("filter_id")
+    public String filterId;
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterResponse.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/FilterResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Matthias Kesler
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.matrix.androidsdk.rest.model.filter;
 
 import com.google.gson.annotations.SerializedName;
@@ -8,7 +24,7 @@ import java.io.Serializable;
  * Represents the body which is the response when creating a filter on the server
  * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
  */
-public class FilterResponse implements Serializable {
+public class FilterResponse {
 
     @SerializedName("filter_id")
     public String filterId;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomEventFilter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomEventFilter.java
@@ -1,0 +1,32 @@
+package org.matrix.androidsdk.rest.model.filter;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Represents "RoomEventFilter" as mentioned in the SPEC
+ * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
+ */
+public class RoomEventFilter implements Serializable {
+
+    public Integer limit;
+
+    @SerializedName("not_senders")
+    public List<String> notSenders;
+
+    @SerializedName("not_types")
+    public List<String> notTypes;
+
+    public List<String> senders;
+
+    public List<String> types;
+
+    public List<String> rooms;
+
+    @SerializedName("not_rooms")
+    public List<String> notRooms;
+
+    public Boolean contains_url;
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomEventFilter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomEventFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Matthias Kesler
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.matrix.androidsdk.rest.model.filter;
 
 import com.google.gson.annotations.SerializedName;
@@ -9,7 +25,7 @@ import java.util.List;
  * Represents "RoomEventFilter" as mentioned in the SPEC
  * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
  */
-public class RoomEventFilter implements Serializable {
+public class RoomEventFilter {
 
     public Integer limit;
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomEventFilter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomEventFilter.java
@@ -44,5 +44,6 @@ public class RoomEventFilter {
     @SerializedName("not_rooms")
     public List<String> notRooms;
 
-    public Boolean contains_url;
+    @SerializedName("contains_url")
+    public Boolean containsUrl;
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomFilter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomFilter.java
@@ -27,7 +27,8 @@ import java.util.List;
  */
 public class RoomFilter {
 
-    public List<String> not_rooms;
+    @SerializedName("not_rooms")
+    public List<String> notRooms;
 
     public List<String> rooms;
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomFilter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomFilter.java
@@ -1,0 +1,29 @@
+package org.matrix.androidsdk.rest.model.filter;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Represents "RoomFilter" as mentioned in the SPEC
+ * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
+ */
+public class RoomFilter implements Serializable {
+
+    public List<String> not_rooms;
+
+    public List<String> rooms;
+
+    public RoomEventFilter ephemeral;
+
+    @SerializedName("include_leave")
+    public Boolean includeLeave;
+
+    public RoomEventFilter state;
+
+    public RoomEventFilter timeline;
+
+    @SerializedName("account_data")
+    public RoomEventFilter accountData;
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomFilter.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/filter/RoomFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Matthias Kesler
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.matrix.androidsdk.rest.model.filter;
 
 import com.google.gson.annotations.SerializedName;
@@ -9,7 +25,7 @@ import java.util.List;
  * Represents "RoomFilter" as mentioned in the SPEC
  * https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-user-userid-filter
  */
-public class RoomFilter implements Serializable {
+public class RoomFilter {
 
     public List<String> not_rooms;
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/sync/EventsThread.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/sync/EventsThread.java
@@ -96,7 +96,7 @@ public class EventsThread extends Thread {
 
     // use dedicated filter when enable
     private boolean mIsInDataSaveMode = false;
-    private String mFilterId;
+    private String mFilterOrFilterId;
 
     private final IMXNetworkEventListener mNetworkListener = new IMXNetworkEventListener() {
         @Override
@@ -152,12 +152,12 @@ public class EventsThread extends Thread {
     }
 
     /**
-     * Set filterId used for /sync requests
+     * Set filterOrFilterId used for /sync requests
      *
-     * @param filterId
+     * @param filterOrFilterId
      */
-    public void setFilter(String filterId) {
-        mFilterId = filterId;
+    public void setFilterOrFilterId(String filterOrFilterId) {
+        mFilterOrFilterId = filterOrFilterId;
     }
 
     /**
@@ -574,12 +574,12 @@ public class EventsThread extends Thread {
 
                 final CountDownLatch latch = new CountDownLatch(1);
 
-                Log.d(LOG_TAG, "Get events from token " + mCurrentToken + " with filter " + mFilterId);
+                Log.d(LOG_TAG, "Get events from token " + mCurrentToken + " with filterOrFilterId " + mFilterOrFilterId);
 
                 final int fServerTimeout = serverTimeout;
                 mNextServerTimeoutms = mDefaultServerTimeoutms;
 
-                mEventsRestClient.syncFromToken(mCurrentToken, serverTimeout, DEFAULT_CLIENT_TIMEOUT_MS, mIsOnline ? null : "offline", mFilterId,
+                mEventsRestClient.syncFromToken(mCurrentToken, serverTimeout, DEFAULT_CLIENT_TIMEOUT_MS, mIsOnline ? null : "offline", mFilterOrFilterId,
                         new SimpleApiCallback<SyncResponse>(mFailureCallback) {
                             @Override
                             public void onSuccess(SyncResponse syncResponse) {


### PR DESCRIPTION
This adds Interfaces to create a Filter which can be send to the server.
This especially handles the DataSaveMode.
The Filter is therefore uploaded in lazy-load manner and used once the
server responds with a filter_id.

This also deprecates "setUseDataSaveMode" and now setSyncFilter should
be used. This is because the app might store the filter-id so the call
for the filter-id could be avoided if the app handles that directly

Signed-Off-by: Matthias Kesler <krombel@krombel.de>