### PR TITLE
fix excessive whitespace on quoted messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  - 
 
 Bugfix:
- - 
+ - Fix excessive whitespace on quoted messages (#348)
 
 API Change:
  - 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/EventDisplay.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/EventDisplay.java
@@ -607,6 +607,11 @@ public class EventDisplay {
                 } else {
                     text = Html.fromHtml(htmlBody, imageGetter, tagHandler);
                 }
+                // fromHtml formats quotes (> character) with two newlines at the end
+                // remove any newlines at the end of the CharSequence
+                while (text.charAt(text.length() - 1) == '\n') {
+                    text = text.subSequence(0, text.length() - 2);
+                }
             }
         }
         return text;


### PR DESCRIPTION
This is not an ideal solution since it will also remove newlines even if a user intended to end a message with whitespace. I just wanted to see what solution you think is best. This code is a lot more simple than whatever would have to be done to selectively remove the newlines following quoted lines.