### PR TITLE
scroll to bottom no longer keeps inertia after position change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bugfix:
  - Fix excessive whitespace on quoted messages (#348)
+ - Scroll to bottom no longer keeps inertia after position change (#354)
 
 API Change:
  - 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -735,6 +735,8 @@ public class MatrixMessageListFragment extends Fragment implements MatrixMessage
             @Override
             public void run() {
                 mMessageListView.setSelection(mAdapter.getCount() - 1);
+                // stop any scroll inertia after the jump
+                mMessageListView.smoothScrollBy(0, 0);
             }
         }, Math.max(delayMs, 0));
     }


### PR DESCRIPTION
You can test the change by scrolling up really fast in a room, then jumping to the bottom of the adapter. The adapter will jump to the latest message but keep scrolling up, this pull request fixes that.