### PR TITLE
Extract patterns and corresponding methods from MXSession to a dedicated MXPatterns class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Bugfix:
 API Change:
  - A Builder has been added to create HomeServerConnectionConfig instances.
  - SentState.UNDELIVERABLE has been renamed to SentState.UNDELIVERED
+ - Extract patterns and corresponding methods from MXSession to a dedicated MXPatterns class.
 
 Translations:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -31,25 +31,27 @@ public class MXPatterns {
         // Cannot be instantiated
     }
 
+    private static final String DOMAIN_REGEX = ":[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
+
     // regex pattern to find matrix user ids in a string.
     // See https://matrix.org/speculator/spec/HEAD/appendices.html#historical-user-ids
-    private static final String MATRIX_USER_IDENTIFIER_REGEX = "@[A-Z0-9\\x21-\\x39\\x3B-\\x7F]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
+    private static final String MATRIX_USER_IDENTIFIER_REGEX = "@[A-Z0-9\\x21-\\x39\\x3B-\\x7F]+" + DOMAIN_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = Pattern.compile(MATRIX_USER_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room ids in a string.
-    private static final String MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
+    private static final String MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9]+" + DOMAIN_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER = Pattern.compile(MATRIX_ROOM_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room aliases in a string.
-    private static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@=+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
+    private static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@=+-]+" + DOMAIN_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find message ids in a string.
-    private static final String MATRIX_EVENT_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
+    private static final String MATRIX_EVENT_IDENTIFIER_REGEX = "\\$[A-Z0-9]+" + DOMAIN_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER = Pattern.compile(MATRIX_EVENT_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find group ids in a string.
-    private static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
+    private static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+" + DOMAIN_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER = Pattern.compile(MATRIX_GROUP_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find permalink with message id.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -31,6 +31,7 @@ public class MXPatterns {
         // Cannot be instantiated
     }
 
+    // Note: TLD is not mandatory (localhost, IP address...)
     private static final String DOMAIN_REGEX = ":[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
 
     // regex pattern to find matrix user ids in a string.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -16,6 +16,8 @@
 
 package org.matrix.androidsdk;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -31,23 +33,23 @@ public class MXPatterns {
     // regex pattern to find matrix user ids in a string.
     // See https://matrix.org/speculator/spec/HEAD/appendices.html#historical-user-ids
     private static final String MATRIX_USER_IDENTIFIER_REGEX = "@[A-Z0-9\\x21-\\x39\\x3B-\\x7F]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    private static final Pattern PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = Pattern.compile(MATRIX_USER_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = Pattern.compile(MATRIX_USER_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room ids in a string.
     private static final String MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    private static final Pattern PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER = Pattern.compile(MATRIX_ROOM_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER = Pattern.compile(MATRIX_ROOM_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room aliases in a string.
     private static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@=+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    private static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find message ids in a string.
     private static final String MATRIX_MESSAGE_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    private static final Pattern PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER = Pattern.compile(MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER = Pattern.compile(MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find group ids in a string.
     private static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    private static final Pattern PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER = Pattern.compile(MATRIX_GROUP_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER = Pattern.compile(MATRIX_GROUP_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find permalink with message id.
     // Android does not support in URL so extract it.
@@ -64,6 +66,19 @@ public class MXPatterns {
     public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ALIAS =
             Pattern.compile("https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/" + MATRIX_ROOM_ALIAS_REGEX + "\\/"
                     + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+
+    // list of patterns to find some matrix item.
+    public static final List<Pattern> MATRIX_PATTERNS = Arrays.asList(
+            MXPatterns.PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ID,
+            MXPatterns.PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ALIAS,
+            MXPatterns.PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ID,
+            MXPatterns.PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ALIAS,
+            MXPatterns.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER,
+            MXPatterns.PATTERN_CONTAIN_MATRIX_ALIAS,
+            MXPatterns.PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER,
+            MXPatterns.PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER,
+            MXPatterns.PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER
+    );
 
     /**
      * Tells if a string is a valid user Id.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -32,7 +32,7 @@ public class MXPatterns {
     }
 
     // Note: TLD is not mandatory (localhost, IP address...)
-    private static final String DOMAIN_REGEX = ":[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
+    private static final String DOMAIN_REGEX = ":[A-Z0-9.-]+(:[0-9]{2,5})?";
 
     // regex pattern to find matrix user ids in a string.
     // See https://matrix.org/speculator/spec/HEAD/appendices.html#historical-user-ids

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -16,6 +16,8 @@
 
 package org.matrix.androidsdk;
 
+import android.support.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -84,50 +86,50 @@ public class MXPatterns {
     /**
      * Tells if a string is a valid user Id.
      *
-     * @param anUserId the string to test
+     * @param str the string to test
      * @return true if the string is a valid user id
      */
-    public static boolean isUserId(String anUserId) {
-        return anUserId != null && PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(anUserId).matches();
+    public static boolean isUserId(@Nullable final String str) {
+        return str != null && PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(str).matches();
     }
 
     /**
      * Tells if a string is a valid room id.
      *
-     * @param aRoomId the string to test
+     * @param str the string to test
      * @return true if the string is a valid room Id
      */
-    public static boolean isRoomId(String aRoomId) {
-        return aRoomId != null && PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER.matcher(aRoomId).matches();
+    public static boolean isRoomId(@Nullable final String str) {
+        return str != null && PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER.matcher(str).matches();
     }
 
     /**
      * Tells if a string is a valid room alias.
      *
-     * @param aRoomAlias the string to test
+     * @param str the string to test
      * @return true if the string is a valid room alias.
      */
-    public static boolean isRoomAlias(String aRoomAlias) {
-        return aRoomAlias != null && PATTERN_CONTAIN_MATRIX_ALIAS.matcher(aRoomAlias).matches();
+    public static boolean isRoomAlias(@Nullable final String str) {
+        return str != null && PATTERN_CONTAIN_MATRIX_ALIAS.matcher(str).matches();
     }
 
     /**
      * Tells if a string is a valid event id.
      *
-     * @param aEventId the string to test
+     * @param str the string to test
      * @return true if the string is a valid event id.
      */
-    public static boolean isEventId(String aEventId) {
-        return aEventId != null && PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER.matcher(aEventId).matches();
+    public static boolean isEventId(@Nullable final String str) {
+        return str != null && PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER.matcher(str).matches();
     }
 
     /**
      * Tells if a string is a valid group id.
      *
-     * @param aGroupId the string to test
+     * @param str the string to test
      * @return true if the string is a valid group id.
      */
-    public static boolean isGroupId(String aGroupId) {
-        return aGroupId != null && PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER.matcher(aGroupId).matches();
+    public static boolean isGroupId(@Nullable final String str) {
+        return str != null && PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER.matcher(str).matches();
     }
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -43,8 +43,8 @@ public class MXPatterns {
     public static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find message ids in a string.
-    private static final String MATRIX_MESSAGE_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    public static final Pattern PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER = Pattern.compile(MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    private static final String MATRIX_EVENT_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    public static final Pattern PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER = Pattern.compile(MATRIX_EVENT_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find group ids in a string.
     private static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
@@ -56,16 +56,16 @@ public class MXPatterns {
     private static final String APP_BASE_REGEX = "https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/";
     private static final String SEP_REGEX = "\\/";
 
-    private static final String LINK_TO_ROOM_ID_REGEXP = PERMALINK_BASE_REGEX + MATRIX_ROOM_IDENTIFIER_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    private static final String LINK_TO_ROOM_ID_REGEXP = PERMALINK_BASE_REGEX + MATRIX_ROOM_IDENTIFIER_REGEX + SEP_REGEX + MATRIX_EVENT_IDENTIFIER_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ID = Pattern.compile(LINK_TO_ROOM_ID_REGEXP, Pattern.CASE_INSENSITIVE);
 
-    private static final String LINK_TO_ROOM_ALIAS_REGEXP = PERMALINK_BASE_REGEX + MATRIX_ROOM_ALIAS_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    private static final String LINK_TO_ROOM_ALIAS_REGEXP = PERMALINK_BASE_REGEX + MATRIX_ROOM_ALIAS_REGEX + SEP_REGEX + MATRIX_EVENT_IDENTIFIER_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ALIAS = Pattern.compile(LINK_TO_ROOM_ALIAS_REGEXP, Pattern.CASE_INSENSITIVE);
 
-    private static final String LINK_TO_APP_ROOM_ID_REGEXP = APP_BASE_REGEX + MATRIX_ROOM_IDENTIFIER_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    private static final String LINK_TO_APP_ROOM_ID_REGEXP = APP_BASE_REGEX + MATRIX_ROOM_IDENTIFIER_REGEX + SEP_REGEX + MATRIX_EVENT_IDENTIFIER_REGEX;
     public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ID = Pattern.compile(LINK_TO_APP_ROOM_ID_REGEXP, Pattern.CASE_INSENSITIVE);
 
-    private static final String LINK_TO_APP_ROOM_ALIAS_REGEXP = APP_BASE_REGEX + MATRIX_ROOM_ALIAS_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    private static final String LINK_TO_APP_ROOM_ALIAS_REGEXP = APP_BASE_REGEX + MATRIX_ROOM_ALIAS_REGEX + SEP_REGEX + MATRIX_EVENT_IDENTIFIER_REGEX;
     public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ALIAS = Pattern.compile(LINK_TO_APP_ROOM_ALIAS_REGEXP, Pattern.CASE_INSENSITIVE);
 
     // list of patterns to find some matrix item.
@@ -77,7 +77,7 @@ public class MXPatterns {
             MXPatterns.PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER,
             MXPatterns.PATTERN_CONTAIN_MATRIX_ALIAS,
             MXPatterns.PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER,
-            MXPatterns.PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER,
+            MXPatterns.PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER,
             MXPatterns.PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER
     );
 
@@ -112,20 +112,20 @@ public class MXPatterns {
     }
 
     /**
-     * Tells if a string is a valid message id.
+     * Tells if a string is a valid event id.
      *
-     * @param aMessageId the string to test
-     * @return true if the string is a valid message id.
+     * @param aEventId the string to test
+     * @return true if the string is a valid event id.
      */
-    public static boolean isMessageId(String aMessageId) {
-        return aMessageId != null && PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER.matcher(aMessageId).matches();
+    public static boolean isEventId(String aEventId) {
+        return aEventId != null && PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER.matcher(aEventId).matches();
     }
 
     /**
      * Tells if a string is a valid group id.
      *
      * @param aGroupId the string to test
-     * @return true if the string is a valid message id.
+     * @return true if the string is a valid group id.
      */
     public static boolean isGroupId(String aGroupId) {
         return aGroupId != null && PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER.matcher(aGroupId).matches();

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk;
+
+import java.util.regex.Pattern;
+
+/**
+ * This class contains pattern to match the different Matrix ids
+ * TODO Add examples of values
+ */
+public class MXPatterns {
+
+    private MXPatterns() {
+        // Cannot be instantiated
+    }
+
+    // regex pattern to find matrix user ids in a string.
+    // See https://matrix.org/speculator/spec/HEAD/appendices.html#historical-user-ids
+    private static final String MATRIX_USER_IDENTIFIER_REGEX = "@[A-Z0-9\\x21-\\x39\\x3B-\\x7F]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final Pattern PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = Pattern.compile(MATRIX_USER_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+
+    // regex pattern to find room ids in a string.
+    private static final String MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final Pattern PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER = Pattern.compile(MATRIX_ROOM_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+
+    // regex pattern to find room aliases in a string.
+    private static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@=+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
+
+    // regex pattern to find message ids in a string.
+    private static final String MATRIX_MESSAGE_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final Pattern PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER = Pattern.compile(MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+
+    // regex pattern to find group ids in a string.
+    private static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final Pattern PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER = Pattern.compile(MATRIX_GROUP_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+
+    // regex pattern to find permalink with message id.
+    // Android does not support in URL so extract it.
+    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ID
+            = Pattern.compile("https:\\/\\/matrix\\.to\\/#\\/" + MATRIX_ROOM_IDENTIFIER_REGEX + "\\/"
+            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ALIAS
+            = Pattern.compile("https:\\/\\/matrix\\.to\\/#\\/" + MATRIX_ROOM_ALIAS_REGEX + "\\/"
+            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+
+    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ID
+            = Pattern.compile("https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/" + MATRIX_ROOM_IDENTIFIER_REGEX + "\\/"
+            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ALIAS =
+            Pattern.compile("https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/" + MATRIX_ROOM_ALIAS_REGEX + "\\/"
+                    + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Tells if a string is a valid user Id.
+     *
+     * @param anUserId the string to test
+     * @return true if the string is a valid user id
+     */
+    public static boolean isUserId(String anUserId) {
+        return (null != anUserId) && PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(anUserId).matches();
+    }
+
+    /**
+     * Tells if a string is a valid room id.
+     *
+     * @param aRoomId the string to test
+     * @return true if the string is a valid room Id
+     */
+    public static boolean isRoomId(String aRoomId) {
+        return (null != aRoomId) && PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER.matcher(aRoomId).matches();
+    }
+
+    /**
+     * Tells if a string is a valid room alias.
+     *
+     * @param aRoomAlias the string to test
+     * @return true if the string is a valid room alias.
+     */
+    public static boolean isRoomAlias(String aRoomAlias) {
+        return (null != aRoomAlias) && PATTERN_CONTAIN_MATRIX_ALIAS.matcher(aRoomAlias).matches();
+    }
+
+    /**
+     * Tells if a string is a valid message id.
+     *
+     * @param aMessageId the string to test
+     * @return true if the string is a valid message id.
+     */
+    public static boolean isMessageId(String aMessageId) {
+        return (null != aMessageId) && PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER.matcher(aMessageId).matches();
+    }
+
+    /**
+     * Tells if a string is a valid group id.
+     *
+     * @param aGroupId the string to test
+     * @return true if the string is a valid message id.
+     */
+    public static boolean isGroupId(String aGroupId) {
+        return (null != aGroupId) && PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER.matcher(aGroupId).matches();
+    }
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -33,30 +33,30 @@ public class MXPatterns {
 
     // regex pattern to find matrix user ids in a string.
     // See https://matrix.org/speculator/spec/HEAD/appendices.html#historical-user-ids
-    private static final String MATRIX_USER_IDENTIFIER_REGEX = "@[A-Z0-9\\x21-\\x39\\x3B-\\x7F]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final String MATRIX_USER_IDENTIFIER_REGEX = "@[A-Z0-9\\x21-\\x39\\x3B-\\x7F]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
     public static final Pattern PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = Pattern.compile(MATRIX_USER_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room ids in a string.
-    private static final String MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final String MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
     public static final Pattern PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER = Pattern.compile(MATRIX_ROOM_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find room aliases in a string.
-    private static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@=+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@=+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
     public static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find message ids in a string.
-    private static final String MATRIX_EVENT_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final String MATRIX_EVENT_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
     public static final Pattern PATTERN_CONTAIN_MATRIX_EVENT_IDENTIFIER = Pattern.compile(MATRIX_EVENT_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find group ids in a string.
-    private static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
+    private static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(:[0-9]{2,})?";
     public static final Pattern PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER = Pattern.compile(MATRIX_GROUP_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
 
     // regex pattern to find permalink with message id.
     // Android does not support in URL so extract it.
-    private static final String PERMALINK_BASE_REGEX = "https:\\/\\/matrix\\.to\\/#\\/";
-    private static final String APP_BASE_REGEX = "https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/";
-    private static final String SEP_REGEX = "\\/";
+    private static final String PERMALINK_BASE_REGEX = "https://matrix\\.to/#/";
+    private static final String APP_BASE_REGEX = "https://[A-Z0-9.-]+\\.[A-Z]{2,}/[A-Z]{3,}/#/room/";
+    private static final String SEP_REGEX = "/";
 
     private static final String LINK_TO_ROOM_ID_REGEXP = PERMALINK_BASE_REGEX + MATRIX_ROOM_IDENTIFIER_REGEX + SEP_REGEX + MATRIX_EVENT_IDENTIFIER_REGEX;
     public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ID = Pattern.compile(LINK_TO_ROOM_ID_REGEXP, Pattern.CASE_INSENSITIVE);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -72,7 +72,7 @@ public class MXPatterns {
      * @return true if the string is a valid user id
      */
     public static boolean isUserId(String anUserId) {
-        return (null != anUserId) && PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(anUserId).matches();
+        return anUserId != null && PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(anUserId).matches();
     }
 
     /**
@@ -82,7 +82,7 @@ public class MXPatterns {
      * @return true if the string is a valid room Id
      */
     public static boolean isRoomId(String aRoomId) {
-        return (null != aRoomId) && PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER.matcher(aRoomId).matches();
+        return aRoomId != null && PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER.matcher(aRoomId).matches();
     }
 
     /**
@@ -92,7 +92,7 @@ public class MXPatterns {
      * @return true if the string is a valid room alias.
      */
     public static boolean isRoomAlias(String aRoomAlias) {
-        return (null != aRoomAlias) && PATTERN_CONTAIN_MATRIX_ALIAS.matcher(aRoomAlias).matches();
+        return aRoomAlias != null && PATTERN_CONTAIN_MATRIX_ALIAS.matcher(aRoomAlias).matches();
     }
 
     /**
@@ -102,7 +102,7 @@ public class MXPatterns {
      * @return true if the string is a valid message id.
      */
     public static boolean isMessageId(String aMessageId) {
-        return (null != aMessageId) && PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER.matcher(aMessageId).matches();
+        return aMessageId != null && PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER.matcher(aMessageId).matches();
     }
 
     /**
@@ -112,6 +112,6 @@ public class MXPatterns {
      * @return true if the string is a valid message id.
      */
     public static boolean isGroupId(String aGroupId) {
-        return (null != aGroupId) && PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER.matcher(aGroupId).matches();
+        return aGroupId != null && PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER.matcher(aGroupId).matches();
     }
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXPatterns.java
@@ -22,7 +22,6 @@ import java.util.regex.Pattern;
 
 /**
  * This class contains pattern to match the different Matrix ids
- * TODO Add examples of values
  */
 public class MXPatterns {
 
@@ -53,19 +52,21 @@ public class MXPatterns {
 
     // regex pattern to find permalink with message id.
     // Android does not support in URL so extract it.
-    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ID
-            = Pattern.compile("https:\\/\\/matrix\\.to\\/#\\/" + MATRIX_ROOM_IDENTIFIER_REGEX + "\\/"
-            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ALIAS
-            = Pattern.compile("https:\\/\\/matrix\\.to\\/#\\/" + MATRIX_ROOM_ALIAS_REGEX + "\\/"
-            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    private static final String PERMALINK_BASE_REGEX = "https:\\/\\/matrix\\.to\\/#\\/";
+    private static final String APP_BASE_REGEX = "https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/";
+    private static final String SEP_REGEX = "\\/";
 
-    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ID
-            = Pattern.compile("https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/" + MATRIX_ROOM_IDENTIFIER_REGEX + "\\/"
-            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ALIAS =
-            Pattern.compile("https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/" + MATRIX_ROOM_ALIAS_REGEX + "\\/"
-                    + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
+    private static final String LINK_TO_ROOM_ID_REGEXP = PERMALINK_BASE_REGEX + MATRIX_ROOM_IDENTIFIER_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ID = Pattern.compile(LINK_TO_ROOM_ID_REGEXP, Pattern.CASE_INSENSITIVE);
+
+    private static final String LINK_TO_ROOM_ALIAS_REGEXP = PERMALINK_BASE_REGEX + MATRIX_ROOM_ALIAS_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ALIAS = Pattern.compile(LINK_TO_ROOM_ALIAS_REGEXP, Pattern.CASE_INSENSITIVE);
+
+    private static final String LINK_TO_APP_ROOM_ID_REGEXP = APP_BASE_REGEX + MATRIX_ROOM_IDENTIFIER_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ID = Pattern.compile(LINK_TO_APP_ROOM_ID_REGEXP, Pattern.CASE_INSENSITIVE);
+
+    private static final String LINK_TO_APP_ROOM_ALIAS_REGEXP = APP_BASE_REGEX + MATRIX_ROOM_ALIAS_REGEX + SEP_REGEX + MATRIX_MESSAGE_IDENTIFIER_REGEX;
+    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ALIAS = Pattern.compile(LINK_TO_APP_ROOM_ALIAS_REGEXP, Pattern.CASE_INSENSITIVE);
 
     // list of patterns to find some matrix item.
     public static final List<Pattern> MATRIX_PATTERNS = Arrays.asList(

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -177,43 +177,6 @@ public class MXSession {
     // load the crypto libs.
     public static OlmManager mOlmManager = new OlmManager();
 
-    // regex pattern to find matrix user ids in a string.
-    // See https://matrix.org/speculator/spec/HEAD/appendices.html#historical-user-ids
-    public static final String MATRIX_USER_IDENTIFIER_REGEX = "@[A-Z0-9\\x21-\\x39\\x3B-\\x7F]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    public static final Pattern PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER = Pattern.compile(MATRIX_USER_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-
-    // regex pattern to find room aliases in a string.
-    public static final String MATRIX_ROOM_ALIAS_REGEX = "#[A-Z0-9._%#@=+-]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    public static final Pattern PATTERN_CONTAIN_MATRIX_ALIAS = Pattern.compile(MATRIX_ROOM_ALIAS_REGEX, Pattern.CASE_INSENSITIVE);
-
-    // regex pattern to find room ids in a string.
-    public static final String MATRIX_ROOM_IDENTIFIER_REGEX = "![A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    public static final Pattern PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER = Pattern.compile(MATRIX_ROOM_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-
-    // regex pattern to find message ids in a string.
-    public static final String MATRIX_MESSAGE_IDENTIFIER_REGEX = "\\$[A-Z0-9]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    public static final Pattern PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER = Pattern.compile(MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-
-    // regex pattern to find group ids in a string.
-    public static final String MATRIX_GROUP_IDENTIFIER_REGEX = "\\+[A-Z0-9=_\\-./]+:[A-Z0-9.-]+(\\.[A-Z]{2,})?+(\\:[0-9]{2,})?";
-    public static final Pattern PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER = Pattern.compile(MATRIX_GROUP_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-
-    // regex pattern to find permalink with message id.
-    // Android does not support in URL so extract it.
-    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ID
-            = Pattern.compile("https:\\/\\/matrix\\.to\\/#\\/" + MATRIX_ROOM_IDENTIFIER_REGEX + "\\/"
-            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-    public static final Pattern PATTERN_CONTAIN_MATRIX_TO_PERMALINK_ROOM_ALIAS
-            = Pattern.compile("https:\\/\\/matrix\\.to\\/#\\/" + MATRIX_ROOM_ALIAS_REGEX + "\\/"
-            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-
-    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ID
-            = Pattern.compile("https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/" + MATRIX_ROOM_IDENTIFIER_REGEX + "\\/"
-            + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-    public static final Pattern PATTERN_CONTAIN_APP_LINK_PERMALINK_ROOM_ALIAS =
-            Pattern.compile("https:\\/\\/[A-Z0-9.-]+\\.[A-Z]{2,}\\/[A-Z]{3,}\\/#\\/room\\/" + MATRIX_ROOM_ALIAS_REGEX + "\\/"
-                    + MATRIX_MESSAGE_IDENTIFIER_REGEX, Pattern.CASE_INSENSITIVE);
-
     /**
      * Create a basic session for direct API calls.
      *
@@ -2398,56 +2361,6 @@ public class MXSession {
                 }
             }
         });
-    }
-
-    /**
-     * Tells if a string is a valid user Id.
-     *
-     * @param anUserId the string to test
-     * @return true if the string is a valid user id
-     */
-    public static boolean isUserId(String anUserId) {
-        return (null != anUserId) && PATTERN_CONTAIN_MATRIX_USER_IDENTIFIER.matcher(anUserId).matches();
-    }
-
-    /**
-     * Tells if a string is a valid room id.
-     *
-     * @param aRoomId the string to test
-     * @return true if the string is a valid room Id
-     */
-    public static boolean isRoomId(String aRoomId) {
-        return (null != aRoomId) && PATTERN_CONTAIN_MATRIX_ROOM_IDENTIFIER.matcher(aRoomId).matches();
-    }
-
-    /**
-     * Tells if a string is a valid room alias.
-     *
-     * @param aRoomAlias the string to test
-     * @return true if the string is a valid room alias.
-     */
-    public static boolean isRoomAlias(String aRoomAlias) {
-        return (null != aRoomAlias) && PATTERN_CONTAIN_MATRIX_ALIAS.matcher(aRoomAlias).matches();
-    }
-
-    /**
-     * Tells if a string is a valid message id.
-     *
-     * @param aMessageId the string to test
-     * @return true if the string is a valid message id.
-     */
-    public static boolean isMessageId(String aMessageId) {
-        return (null != aMessageId) && PATTERN_CONTAIN_MATRIX_MESSAGE_IDENTIFIER.matcher(aMessageId).matches();
-    }
-
-    /**
-     * Tells if a string is a valid group id.
-     *
-     * @param aGroupId the string to test
-     * @return true if the string is a valid message id.
-     */
-    public static boolean isGroupId(String aGroupId) {
-        return (null != aGroupId) && PATTERN_CONTAIN_MATRIX_GROUP_IDENTIFIER.matcher(aGroupId).matches();
     }
 
     /**

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/call/MXCallsManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/call/MXCallsManager.java
@@ -27,6 +27,7 @@ import android.util.Base64;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import org.matrix.androidsdk.MXPatterns;
 import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.crypto.MXCryptoError;
 import org.matrix.androidsdk.crypto.data.MXDeviceInfo;
@@ -1011,7 +1012,7 @@ public class MXCallsManager {
         if (!TextUtils.isEmpty(userId) && userId.startsWith(prefix) && userId.endsWith(suffix)) {
             String roomIdBase64 = userId.substring(prefix.length(), userId.length() - suffix.length());
             try {
-                res = MXSession.isRoomId((new String(Base64.decode(roomIdBase64, Base64.NO_WRAP | Base64.URL_SAFE), "UTF-8")));
+                res = MXPatterns.isRoomId((new String(Base64.decode(roomIdBase64, Base64.NO_WRAP | Base64.URL_SAFE), "UTF-8")));
             } catch (Exception e) {
                 Log.e(LOG_TAG, "isConferenceUserId : failed " + e.getMessage(), e);
             }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXDeviceList.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXDeviceList.java
@@ -19,6 +19,7 @@ package org.matrix.androidsdk.crypto;
 
 import android.text.TextUtils;
 
+import org.matrix.androidsdk.MXPatterns;
 import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.crypto.data.MXDeviceInfo;
 import org.matrix.androidsdk.crypto.data.MXUsersDevicesMap;
@@ -174,7 +175,7 @@ public class MXDeviceList {
             List<String> invalidUserIds = new ArrayList<>();
 
             for (String userId : userIds) {
-                if (MXSession.isUserId(userId)) {
+                if (MXPatterns.isUserId(userId)) {
                     filteredUserIds.add(userId);
                 } else {
                     Log.e(LOG_TAG, "## userId " + userId + "is not a valid user id");

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -40,7 +40,6 @@ import com.google.gson.reflect.TypeToken;
 
 import org.matrix.androidsdk.MXDataHandler;
 import org.matrix.androidsdk.MXPatterns;
-import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.call.MXCallsManager;
 import org.matrix.androidsdk.crypto.MXCryptoError;
 import org.matrix.androidsdk.crypto.data.MXEncryptEventContentResult;
@@ -1443,7 +1442,7 @@ public class Room {
 
         String readMarkerEventId = aReadMarkerEventId;
         if (!TextUtils.isEmpty(aReadMarkerEventId)) {
-            if (!MXPatterns.isMessageId(aReadMarkerEventId)) {
+            if (!MXPatterns.isEventId(aReadMarkerEventId)) {
                 Log.e(LOG_TAG, "## sendReadMarkers() : invalid event id " + readMarkerEventId);
                 // Read marker is invalid, ignore it
                 readMarkerEventId = null;
@@ -1503,8 +1502,8 @@ public class Room {
         Log.d(LOG_TAG, "## setReadMarkers(): readMarkerEventId " + aReadMarkerEventId + " readReceiptEventId " + aReadMarkerEventId);
 
         // check if the message ids are valid
-        final String readMarkerEventId = MXPatterns.isMessageId(aReadMarkerEventId) ? aReadMarkerEventId : null;
-        final String readReceiptEventId = MXPatterns.isMessageId(aReadReceiptEventId) ? aReadReceiptEventId : null;
+        final String readMarkerEventId = MXPatterns.isEventId(aReadMarkerEventId) ? aReadMarkerEventId : null;
+        final String readReceiptEventId = MXPatterns.isEventId(aReadReceiptEventId) ? aReadReceiptEventId : null;
 
         // if there is nothing to do
         if (TextUtils.isEmpty(readMarkerEventId) && TextUtils.isEmpty(readReceiptEventId)) {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -39,6 +39,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 
 import org.matrix.androidsdk.MXDataHandler;
+import org.matrix.androidsdk.MXPatterns;
 import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.call.MXCallsManager;
 import org.matrix.androidsdk.crypto.MXCryptoError;
@@ -1442,7 +1443,7 @@ public class Room {
 
         String readMarkerEventId = aReadMarkerEventId;
         if (!TextUtils.isEmpty(aReadMarkerEventId)) {
-            if (!MXSession.isMessageId(aReadMarkerEventId)) {
+            if (!MXPatterns.isMessageId(aReadMarkerEventId)) {
                 Log.e(LOG_TAG, "## sendReadMarkers() : invalid event id " + readMarkerEventId);
                 // Read marker is invalid, ignore it
                 readMarkerEventId = null;
@@ -1502,8 +1503,8 @@ public class Room {
         Log.d(LOG_TAG, "## setReadMarkers(): readMarkerEventId " + aReadMarkerEventId + " readReceiptEventId " + aReadMarkerEventId);
 
         // check if the message ids are valid
-        final String readMarkerEventId = MXSession.isMessageId(aReadMarkerEventId) ? aReadMarkerEventId : null;
-        final String readReceiptEventId = MXSession.isMessageId(aReadReceiptEventId) ? aReadReceiptEventId : null;
+        final String readMarkerEventId = MXPatterns.isMessageId(aReadMarkerEventId) ? aReadMarkerEventId : null;
+        final String readReceiptEventId = MXPatterns.isMessageId(aReadReceiptEventId) ? aReadReceiptEventId : null;
 
         // if there is nothing to do
         if (TextUtils.isEmpty(readMarkerEventId) && TextUtils.isEmpty(readReceiptEventId)) {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/groups/GroupsManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/groups/GroupsManager.java
@@ -22,7 +22,7 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.matrix.androidsdk.MXDataHandler;
-import org.matrix.androidsdk.MXSession;
+import org.matrix.androidsdk.MXPatterns;
 import org.matrix.androidsdk.data.store.IMXStore;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
@@ -566,7 +566,7 @@ public class GroupsManager {
         Log.d(LOG_TAG, "## getUserPublicisedGroups() : " + userId);
 
         // sanity check
-        if (!MXSession.isUserId(userId)) {
+        if (!MXPatterns.isUserId(userId)) {
             mUIHandler.post(new Runnable() {
                 @Override
                 public void run() {
@@ -716,7 +716,7 @@ public class GroupsManager {
         }
 
         // valid group id
-        if (TextUtils.isEmpty(groupId) || !MXSession.isGroupId(groupId)) {
+        if (TextUtils.isEmpty(groupId) || !MXPatterns.isGroupId(groupId)) {
             mUIHandler.post(new Runnable() {
                 @Override
                 public void run() {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/CreateRoomParams.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/CreateRoomParams.java
@@ -20,7 +20,7 @@ package org.matrix.androidsdk.rest.model;
 import android.text.TextUtils;
 
 import org.matrix.androidsdk.HomeServerConnectionConfig;
-import org.matrix.androidsdk.MXSession;
+import org.matrix.androidsdk.MXPatterns;
 import org.matrix.androidsdk.data.RoomState;
 import org.matrix.androidsdk.rest.model.pid.Invite3Pid;
 import org.matrix.androidsdk.rest.model.pid.ThreePid;
@@ -234,7 +234,7 @@ public class CreateRoomParams {
                 pid.address = id;
 
                 invite_3pid.add(pid);
-            } else if (MXSession.isUserId(id)) {
+            } else if (MXPatterns.isUserId(id)) {
                 // do not invite oneself
                 if (!TextUtils.equals(hsConfig.getCredentials().userId, id)) {
                     if (null == invite) {

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/MxPatternsTest.java
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/MxPatternsTest.java
@@ -64,21 +64,21 @@ public class MxPatternsTest {
 
     @Test
     public void MxPatterns_common_error_null() {
-        testAllFalse(null);
+        assertAllFalse(null);
     }
 
     @Test
     public void MxPatterns_common_error_empty() {
-        testAllFalse("");
+        assertAllFalse("");
     }
 
     @Test
     public void MxPatterns_common_error_invalidPrefix() {
-        testAllFalse("a");
-        testAllFalse("1");
-        testAllFalse("test@example.org");
-        testAllFalse("https://www.example.org");
-        testAllFalse("benoit:matrix.org");
+        assertAllFalse("a");
+        assertAllFalse("1");
+        assertAllFalse("test@example.org");
+        assertAllFalse("https://www.example.org");
+        assertAllFalse("benoit:matrix.org");
     }
 
     /* ==========================================================================================
@@ -87,36 +87,36 @@ public class MxPatternsTest {
 
     @Test
     public void MxPatterns_common_ok() {
-        testAllTrueWithCorrectPrefix("id:matrix.org");
-        testAllTrueWithCorrectPrefix("id:matrix.org:80");
-        testAllTrueWithCorrectPrefix("id:matrix.org:808");
-        testAllTrueWithCorrectPrefix("id:matrix.org:8080");
-        testAllTrueWithCorrectPrefix("id:matrix.org:65535");
+        assertAllTrueWithCorrectPrefix("id:matrix.org");
+        assertAllTrueWithCorrectPrefix("id:matrix.org:80");
+        assertAllTrueWithCorrectPrefix("id:matrix.org:808");
+        assertAllTrueWithCorrectPrefix("id:matrix.org:8080");
+        assertAllTrueWithCorrectPrefix("id:matrix.org:65535");
     }
 
     @Test
     public void MxPatterns_common_ok_dash() {
-        testAllTrueWithCorrectPrefix("id:matrix-new.org");
-        testAllTrueWithCorrectPrefix("id:matrix-new.org:80");
-        testAllTrueWithCorrectPrefix("id:matrix-new.org:808");
-        testAllTrueWithCorrectPrefix("id:matrix-new.org:8080");
-        testAllTrueWithCorrectPrefix("id:matrix-new.org:65535");
+        assertAllTrueWithCorrectPrefix("id:matrix-new.org");
+        assertAllTrueWithCorrectPrefix("id:matrix-new.org:80");
+        assertAllTrueWithCorrectPrefix("id:matrix-new.org:808");
+        assertAllTrueWithCorrectPrefix("id:matrix-new.org:8080");
+        assertAllTrueWithCorrectPrefix("id:matrix-new.org:65535");
     }
 
     @Test
     public void MxPatterns_common_ok_localhost() {
-        testAllTrueWithCorrectPrefix("id:localhost");
-        testAllTrueWithCorrectPrefix("id:localhost:8080");
-        testAllTrueWithCorrectPrefix("id:localhost:65535");
+        assertAllTrueWithCorrectPrefix("id:localhost");
+        assertAllTrueWithCorrectPrefix("id:localhost:8080");
+        assertAllTrueWithCorrectPrefix("id:localhost:65535");
     }
 
     @Test
     public void MxPatterns_common_ok_ipAddress() {
-        testAllTrueWithCorrectPrefix("id:1.1.1.1");
-        testAllTrueWithCorrectPrefix("id:1.1.1.1:8080");
-        testAllTrueWithCorrectPrefix("id:888.888.888.888");
-        testAllTrueWithCorrectPrefix("id:888.888.888.888:8080");
-        testAllTrueWithCorrectPrefix("id:888.888.888.888:65535");
+        assertAllTrueWithCorrectPrefix("id:1.1.1.1");
+        assertAllTrueWithCorrectPrefix("id:1.1.1.1:8080");
+        assertAllTrueWithCorrectPrefix("id:888.888.888.888");
+        assertAllTrueWithCorrectPrefix("id:888.888.888.888:8080");
+        assertAllTrueWithCorrectPrefix("id:888.888.888.888:65535");
     }
 
     /* ==========================================================================================
@@ -125,37 +125,37 @@ public class MxPatternsTest {
 
     @Test
     public void MxPatterns_common_error_with_prefix_invalidChars() {
-        testAllFalseWithCorrectPrefix("idé:matrix.org");
-        testAllFalseWithCorrectPrefix("id :matrix.org");
+        assertAllFalseWithCorrectPrefix("idé:matrix.org");
+        assertAllFalseWithCorrectPrefix("id :matrix.org");
     }
 
     @Test
     public void MxPatterns_common_error_with_prefix_empty() {
-        testAllFalseWithCorrectPrefix("");
+        assertAllFalseWithCorrectPrefix("");
     }
 
     @Test
     public void MxPatterns_common_error_with_prefix_noTwoPoint() {
-        testAllFalseWithCorrectPrefix("idmatrix.org");
+        assertAllFalseWithCorrectPrefix("idmatrix.org");
     }
 
     @Test
     public void MxPatterns_common_error_with_prefix_noId() {
-        testAllFalseWithCorrectPrefix(":matrix.org");
+        assertAllFalseWithCorrectPrefix(":matrix.org");
     }
 
     @Test
     public void MxPatterns_common_error_with_prefix_noDomain() {
-        testAllFalseWithCorrectPrefix("id:");
+        assertAllFalseWithCorrectPrefix("id:");
     }
 
     @Test
     public void MxPatterns_common_error_with_prefix_bad_port() {
-        testAllFalseWithCorrectPrefix("id:matrix.org:");
-        testAllFalseWithCorrectPrefix("id:matrix.org:8");
-        testAllFalseWithCorrectPrefix("id:matrix.org:abc");
-        testAllFalseWithCorrectPrefix("id:matrix.org:8080a");
-        testAllFalseWithCorrectPrefix("id:matrix.org:808080");
+        assertAllFalseWithCorrectPrefix("id:matrix.org:");
+        assertAllFalseWithCorrectPrefix("id:matrix.org:8");
+        assertAllFalseWithCorrectPrefix("id:matrix.org:abc");
+        assertAllFalseWithCorrectPrefix("id:matrix.org:8080a");
+        assertAllFalseWithCorrectPrefix("id:matrix.org:808080");
     }
 
     /* ==========================================================================================
@@ -229,7 +229,7 @@ public class MxPatternsTest {
      * Private methods
      * ========================================================================================== */
 
-    private void testAllTrueWithCorrectPrefix(String value) {
+    private void assertAllTrueWithCorrectPrefix(String value) {
         Assert.assertTrue(MXPatterns.isUserId("@" + value));
         Assert.assertTrue(MXPatterns.isRoomId("!" + value));
         Assert.assertTrue(MXPatterns.isRoomAlias("#" + value));
@@ -237,15 +237,15 @@ public class MxPatternsTest {
         Assert.assertTrue(MXPatterns.isGroupId("+" + value));
     }
 
-    private void testAllFalseWithCorrectPrefix(String value) {
-        testAllFalse("@" + value);
-        testAllFalse("!" + value);
-        testAllFalse("#" + value);
-        testAllFalse("$" + value);
-        testAllFalse("+" + value);
+    private void assertAllFalseWithCorrectPrefix(String value) {
+        assertAllFalse("@" + value);
+        assertAllFalse("!" + value);
+        assertAllFalse("#" + value);
+        assertAllFalse("$" + value);
+        assertAllFalse("+" + value);
     }
 
-    private void testAllFalse(String value) {
+    private void assertAllFalse(String value) {
         Assert.assertFalse(MXPatterns.isUserId(value));
         Assert.assertFalse(MXPatterns.isRoomId(value));
         Assert.assertFalse(MXPatterns.isRoomAlias(value));

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/MxPatternsTest.java
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/MxPatternsTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class TestMxPatterns {
+public class MxPatternsTest {
 
     private static final List<String> validUserIds = Arrays.asList(
             "@benoit:matrix.org",

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/MxPatternsTest.java
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/MxPatternsTest.java
@@ -114,6 +114,8 @@ public class MxPatternsTest {
     public void MxPatterns_common_ok_ipAddress() {
         assertAllTrueWithCorrectPrefix("id:1.1.1.1");
         assertAllTrueWithCorrectPrefix("id:1.1.1.1:8080");
+        assertAllTrueWithCorrectPrefix("id:1.1.1.1:65535");
+
         assertAllTrueWithCorrectPrefix("id:888.888.888.888");
         assertAllTrueWithCorrectPrefix("id:888.888.888.888:8080");
         assertAllTrueWithCorrectPrefix("id:888.888.888.888:65535");

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
@@ -73,7 +73,7 @@ public class TestMxPatterns {
     }
 
     @Test
-    public void MxPatterns_common_error_invalid() {
+    public void MxPatterns_common_error_invalidPrefix() {
         testAllFalse("a");
         testAllFalse("1");
         testAllFalse("test@example.org");
@@ -91,6 +91,28 @@ public class TestMxPatterns {
         testAllTrueWithCorrectPrefix("id:matrix.org:80");
         testAllTrueWithCorrectPrefix("id:matrix.org:808");
         testAllTrueWithCorrectPrefix("id:matrix.org:8080");
+    }
+
+    @Test
+    public void MxPatterns_common_ok_dash() {
+        testAllTrueWithCorrectPrefix("id:matrix-new.org");
+        testAllTrueWithCorrectPrefix("id:matrix-new.org:80");
+        testAllTrueWithCorrectPrefix("id:matrix-new.org:808");
+        testAllTrueWithCorrectPrefix("id:matrix-new.org:8080");
+    }
+
+    @Test
+    public void MxPatterns_common_ok_localhost() {
+        testAllTrueWithCorrectPrefix("id:localhost");
+        testAllTrueWithCorrectPrefix("id:localhost:8080");
+    }
+
+    @Test
+    public void MxPatterns_common_ok_ipAddress() {
+        testAllTrueWithCorrectPrefix("id:1.1.1.1");
+        testAllTrueWithCorrectPrefix("id:1.1.1.1:8080");
+        testAllTrueWithCorrectPrefix("id:888.888.888.888");
+        testAllTrueWithCorrectPrefix("id:888.888.888.888:8080");
     }
 
     /* ==========================================================================================
@@ -120,7 +142,8 @@ public class TestMxPatterns {
 
     @Test
     public void MxPatterns_common_error_noTld() {
-        testAllFalseWithCorrectPrefix("id:matrix");
+        // Tld is not mandatory
+        // testAllFalseWithCorrectPrefix("id:matrix");
         testAllFalseWithCorrectPrefix("id:matrix.");
     }
 

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
@@ -124,28 +124,33 @@ public class TestMxPatterns {
      * ========================================================================================== */
 
     @Test
-    public void MxPatterns_common_error_invalidChars() {
+    public void MxPatterns_common_error_with_prefix_invalidChars() {
         testAllFalseWithCorrectPrefix("idé:matrix.org");
         testAllFalseWithCorrectPrefix("id :matrix.org");
     }
 
     @Test
-    public void MxPatterns_common_error_noTwoPoint() {
+    public void MxPatterns_common_error_with_prefix_empty() {
+        testAllFalseWithCorrectPrefix("");
+    }
+
+    @Test
+    public void MxPatterns_common_error_with_prefix_noTwoPoint() {
         testAllFalseWithCorrectPrefix("idmatrix.org");
     }
 
     @Test
-    public void MxPatterns_common_error_noId() {
+    public void MxPatterns_common_error_with_prefix_noId() {
         testAllFalseWithCorrectPrefix(":matrix.org");
     }
 
     @Test
-    public void MxPatterns_common_error_noDomain() {
+    public void MxPatterns_common_error_with_prefix_noDomain() {
         testAllFalseWithCorrectPrefix("id:");
     }
 
     @Test
-    public void MxPatterns_common_error_bad_port() {
+    public void MxPatterns_common_error_with_prefix_bad_port() {
         testAllFalseWithCorrectPrefix("id:matrix.org:");
         testAllFalseWithCorrectPrefix("id:matrix.org:8");
         testAllFalseWithCorrectPrefix("id:matrix.org:abc");

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk;
+
+import junit.framework.Assert;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.Arrays;
+import java.util.List;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestMxPatterns {
+
+    private static final List<String> validUserIds = Arrays.asList(
+            "@benoit:matrix.org",
+            "@benoit:matrix.org:1234"
+    );
+
+    private static final List<String> validRoomIds = Arrays.asList(
+            "!fLXbhWnqiSoyBfgGgb:matrix.org",
+            "!fLXbhWnqiSoyBfgGgb:matrix.org:1234"
+    );
+
+    private static final List<String> validRoomAliasIds = Arrays.asList(
+            "#linux:matrix.org",
+            "#linux:matrix.org:1234",
+            // Room alias can contain special char: ._%#@=+-
+            "#linux._%#@=+-:matrix.org:1234"
+    );
+
+    private static final List<String> validEventIds = Arrays.asList(
+            "$1536732077213115wbNdt:matrix.org",
+            "$1536732077213115wbNdt:matrix.org:1234"
+    );
+
+    private static final List<String> validGroupIds = Arrays.asList(
+            "+matrix:matrix.org",
+            "+matrix:matrix.org:1234",
+            // Group id special char
+            "+matrix=_-./:matrix.org:1234"
+
+    );
+
+    /* ==========================================================================================
+     * Common error cases
+     * ========================================================================================== */
+
+    @Test
+    public void MxPatterns_common_error_null() {
+        testAllFalse(null);
+    }
+
+    @Test
+    public void MxPatterns_common_error_empty() {
+        testAllFalse("");
+    }
+
+    @Test
+    public void MxPatterns_common_error_invalid() {
+        testAllFalse("a");
+        testAllFalse("1");
+        testAllFalse("test@example.org");
+        testAllFalse("https://www.example.org");
+        testAllFalse("benoit:matrix.org");
+    }
+
+    /* ==========================================================================================
+     * Common valid cases
+     * ========================================================================================== */
+
+    @Test
+    public void MxPatterns_common_ok() {
+        testAllTrueWithCorrectPrefix("id:matrix.org");
+        testAllTrueWithCorrectPrefix("id:matrix.org:80");
+        testAllTrueWithCorrectPrefix("id:matrix.org:808");
+        testAllTrueWithCorrectPrefix("id:matrix.org:8080");
+    }
+
+    /* ==========================================================================================
+     * Common error cases using correct prefix
+     * ========================================================================================== */
+
+    @Test
+    public void MxPatterns_common_error_invalidChars() {
+        testAllFalseWithCorrectPrefix("idé:matrix.org");
+        testAllFalseWithCorrectPrefix("id :matrix.org");
+    }
+
+    @Test
+    public void MxPatterns_common_error_noTwoPoint() {
+        testAllFalseWithCorrectPrefix("idmatrix.org");
+    }
+
+    @Test
+    public void MxPatterns_common_error_noId() {
+        testAllFalseWithCorrectPrefix(":matrix.org");
+    }
+
+    @Test
+    public void MxPatterns_common_error_noDomain() {
+        testAllFalseWithCorrectPrefix("id:.org");
+    }
+
+    @Test
+    public void MxPatterns_common_error_noTld() {
+        testAllFalseWithCorrectPrefix("id:matrix");
+        testAllFalseWithCorrectPrefix("id:matrix.");
+    }
+
+    @Test
+    public void MxPatterns_common_error_bad_port() {
+        testAllFalseWithCorrectPrefix("id:matrix.org:");
+        testAllFalseWithCorrectPrefix("id:matrix.org:8");
+        testAllFalseWithCorrectPrefix("id:matrix.org:abc");
+        testAllFalseWithCorrectPrefix("id:matrix.org:8080a");
+    }
+
+    /* ==========================================================================================
+     * Valid cases
+     * ========================================================================================== */
+
+    @Test
+    public void MxPatterns_userId_ok() {
+        for (String value : validUserIds) {
+            Assert.assertTrue(MXPatterns.isUserId(value));
+
+            Assert.assertFalse(MXPatterns.isRoomId(value));
+            Assert.assertFalse(MXPatterns.isRoomAlias(value));
+            Assert.assertFalse(MXPatterns.isEventId(value));
+            Assert.assertFalse(MXPatterns.isGroupId(value));
+        }
+    }
+
+    @Test
+    public void MxPatterns_roomId_ok() {
+        for (String value : validRoomIds) {
+            Assert.assertFalse(MXPatterns.isUserId(value));
+
+            Assert.assertTrue(MXPatterns.isRoomId(value));
+
+            Assert.assertFalse(MXPatterns.isRoomAlias(value));
+            Assert.assertFalse(MXPatterns.isEventId(value));
+            Assert.assertFalse(MXPatterns.isGroupId(value));
+        }
+    }
+
+    @Test
+    public void MxPatterns_roomAlias_ok() {
+        for (String value : validRoomAliasIds) {
+            Assert.assertFalse(MXPatterns.isUserId(value));
+            Assert.assertFalse(MXPatterns.isRoomId(value));
+
+            Assert.assertTrue(MXPatterns.isRoomAlias(value));
+
+            Assert.assertFalse(MXPatterns.isEventId(value));
+            Assert.assertFalse(MXPatterns.isGroupId(value));
+        }
+    }
+
+    @Test
+    public void MxPatterns_eventId_ok() {
+        for (String value : validEventIds) {
+            Assert.assertFalse(MXPatterns.isUserId(value));
+            Assert.assertFalse(MXPatterns.isRoomId(value));
+            Assert.assertFalse(MXPatterns.isRoomAlias(value));
+
+            Assert.assertTrue(MXPatterns.isEventId(value));
+
+            Assert.assertFalse(MXPatterns.isGroupId(value));
+        }
+    }
+
+    @Test
+    public void MxPatterns_groupId_ok() {
+        for (String value : validGroupIds) {
+            Assert.assertFalse(MXPatterns.isUserId(value));
+            Assert.assertFalse(MXPatterns.isRoomId(value));
+            Assert.assertFalse(MXPatterns.isRoomAlias(value));
+            Assert.assertFalse(MXPatterns.isEventId(value));
+
+            Assert.assertTrue(MXPatterns.isGroupId(value));
+        }
+    }
+
+    /* ==========================================================================================
+     * Private methods
+     * ========================================================================================== */
+
+    private void testAllTrueWithCorrectPrefix(String value) {
+        Assert.assertTrue(MXPatterns.isUserId("@" + value));
+        Assert.assertTrue(MXPatterns.isRoomId("!" + value));
+        Assert.assertTrue(MXPatterns.isRoomAlias("#" + value));
+        Assert.assertTrue(MXPatterns.isEventId("$" + value));
+        Assert.assertTrue(MXPatterns.isGroupId("+" + value));
+    }
+
+    private void testAllFalseWithCorrectPrefix(String value) {
+        testAllFalse("@" + value);
+        testAllFalse("!" + value);
+        testAllFalse("#" + value);
+        testAllFalse("$" + value);
+        testAllFalse("+" + value);
+    }
+
+    private void testAllFalse(String value) {
+        Assert.assertFalse(MXPatterns.isUserId(value));
+        Assert.assertFalse(MXPatterns.isRoomId(value));
+        Assert.assertFalse(MXPatterns.isRoomAlias(value));
+        Assert.assertFalse(MXPatterns.isEventId(value));
+        Assert.assertFalse(MXPatterns.isGroupId(value));
+    }
+}

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/TestMxPatterns.java
@@ -91,6 +91,7 @@ public class TestMxPatterns {
         testAllTrueWithCorrectPrefix("id:matrix.org:80");
         testAllTrueWithCorrectPrefix("id:matrix.org:808");
         testAllTrueWithCorrectPrefix("id:matrix.org:8080");
+        testAllTrueWithCorrectPrefix("id:matrix.org:65535");
     }
 
     @Test
@@ -99,12 +100,14 @@ public class TestMxPatterns {
         testAllTrueWithCorrectPrefix("id:matrix-new.org:80");
         testAllTrueWithCorrectPrefix("id:matrix-new.org:808");
         testAllTrueWithCorrectPrefix("id:matrix-new.org:8080");
+        testAllTrueWithCorrectPrefix("id:matrix-new.org:65535");
     }
 
     @Test
     public void MxPatterns_common_ok_localhost() {
         testAllTrueWithCorrectPrefix("id:localhost");
         testAllTrueWithCorrectPrefix("id:localhost:8080");
+        testAllTrueWithCorrectPrefix("id:localhost:65535");
     }
 
     @Test
@@ -113,6 +116,7 @@ public class TestMxPatterns {
         testAllTrueWithCorrectPrefix("id:1.1.1.1:8080");
         testAllTrueWithCorrectPrefix("id:888.888.888.888");
         testAllTrueWithCorrectPrefix("id:888.888.888.888:8080");
+        testAllTrueWithCorrectPrefix("id:888.888.888.888:65535");
     }
 
     /* ==========================================================================================
@@ -137,14 +141,7 @@ public class TestMxPatterns {
 
     @Test
     public void MxPatterns_common_error_noDomain() {
-        testAllFalseWithCorrectPrefix("id:.org");
-    }
-
-    @Test
-    public void MxPatterns_common_error_noTld() {
-        // Tld is not mandatory
-        // testAllFalseWithCorrectPrefix("id:matrix");
-        testAllFalseWithCorrectPrefix("id:matrix.");
+        testAllFalseWithCorrectPrefix("id:");
     }
 
     @Test
@@ -153,6 +150,7 @@ public class TestMxPatterns {
         testAllFalseWithCorrectPrefix("id:matrix.org:8");
         testAllFalseWithCorrectPrefix("id:matrix.org:abc");
         testAllFalseWithCorrectPrefix("id:matrix.org:8080a");
+        testAllFalseWithCorrectPrefix("id:matrix.org:808080");
     }
 
     /* ==========================================================================================


### PR DESCRIPTION
It fixes issue on unitary test, because MXSession cannot be loaded in UT due to Olm lib
