### PR TITLE
TLS configuration - Enable retro-compatibility for android < 20

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
@@ -482,10 +482,10 @@ public class HomeServerConnectionConfig {
          * - https://developer.android.com/reference/javax/net/ssl/SSLEngine
          *
          * @param tlsLimitations         true to use Tls limitations
-         * @param forceUsageOfTlsVersion set to true for Android < 20
+         * @param enableCompatibilityMode set to true for Android < 20
          * @return this builder
          */
-        public Builder withTlsLimitations(boolean tlsLimitations, boolean forceUsageOfTlsVersion) {
+        public Builder withTlsLimitations(boolean tlsLimitations, boolean enableCompatibilityMode) {
             if (tlsLimitations) {
                 withShouldAcceptTlsExtensions(false);
 
@@ -493,7 +493,7 @@ public class HomeServerConnectionConfig {
                 addAcceptedTlsVersion(TlsVersion.TLS_1_2);
                 addAcceptedTlsVersion(TlsVersion.TLS_1_3);
 
-                forceUsageOfTlsVersions(forceUsageOfTlsVersion);
+                forceUsageOfTlsVersions(enableCompatibilityMode);
 
                 // Cipher suites
                 addAcceptedTlsCipherSuite(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256);
@@ -504,6 +504,13 @@ public class HomeServerConnectionConfig {
                 addAcceptedTlsCipherSuite(CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384);
                 addAcceptedTlsCipherSuite(CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256);
                 addAcceptedTlsCipherSuite(CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256);
+
+                if (enableCompatibilityMode) {
+                    // Adopt some preceding cipher suites for Android < 20 to be able to negotiate
+                    // a TLS session.
+                    addAcceptedTlsCipherSuite(CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA);
+                    addAcceptedTlsCipherSuite(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA);
+                }
             }
 
             return this;


### PR DESCRIPTION
HomeServerConnectionConfig: adopt some preceding cipher suites for Android < 20 to be able to negotiate a TLS session.