### PR TITLE
 Enable CLEARTEXT communication for http endpoints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  - Improve certificate pinning management for HomeServerConnectionConfig.
 
 Bugfix:
- -
+ - Enable CLEARTEXT communication for http endpoints (vector-im/riot-android#2495)
 
 API Change:
  -

--- a/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/common/CommonTestHelper.java
+++ b/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/common/CommonTestHelper.java
@@ -76,7 +76,6 @@ public class CommonTestHelper {
         final HomeServerConnectionConfig hs = new HomeServerConnectionConfig.Builder()
                 .withHomeServerUri(Uri.parse(TestConstants.TESTS_HOME_SERVER_URL))
                 .withCredentials(credentials)
-                .withAllowHttpConnection()
                 .build();
         return hs;
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
@@ -20,7 +20,6 @@ package org.matrix.androidsdk;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -57,8 +56,6 @@ public class HomeServerConnectionConfig {
     private List<CipherSuite> mTlsCipherSuites;
     // should accept TLS extensions
     private boolean mShouldAcceptTlsExtensions = true;
-    // allow Http connection
-    private boolean mAllowHttpExtension;
     // Force usage of TLS versions
     private boolean mForceUsageTlsVersions;
 
@@ -159,13 +156,6 @@ public class HomeServerConnectionConfig {
      */
     public boolean shouldAcceptTlsExtensions() {
         return mShouldAcceptTlsExtensions;
-    }
-
-    /**
-     * @return true if Http connection is allowed (false by default).
-     */
-    public boolean isHttpConnectionAllowed() {
-        return mAllowHttpExtension;
     }
 
     /**
@@ -473,15 +463,6 @@ public class HomeServerConnectionConfig {
 
             mHomeServerConnectionConfig.mAntiVirusServerUri = antivirusServerUri;
 
-            return this;
-        }
-
-        /**
-         * For test only: allow Http connection
-         */
-        @VisibleForTesting
-        public Builder withAllowHttpConnection() {
-            mHomeServerConnectionConfig.mAllowHttpExtension = true;
             return this;
         }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/HomeServerConnectionConfig.java
@@ -39,7 +39,7 @@ import okhttp3.TlsVersion;
 public class HomeServerConnectionConfig {
 
     // the home server URI
-    private Uri mHsUri;
+    private Uri mHomeServerUri;
     // the identity server URI
     private Uri mIdentityServerUri;
     // the anti-virus server URI
@@ -72,14 +72,14 @@ public class HomeServerConnectionConfig {
      * @param uri the new HS uri
      */
     public void setHomeserverUri(Uri uri) {
-        mHsUri = uri;
+        mHomeServerUri = uri;
     }
 
     /**
      * @return the home server uri
      */
     public Uri getHomeserverUri() {
-        return mHsUri;
+        return mHomeServerUri;
     }
 
     /**
@@ -90,7 +90,7 @@ public class HomeServerConnectionConfig {
             return mIdentityServerUri;
         }
         // Else consider the HS uri by default.
-        return mHsUri;
+        return mHomeServerUri;
     }
 
     /**
@@ -101,7 +101,7 @@ public class HomeServerConnectionConfig {
             return mAntiVirusServerUri;
         }
         // Else consider the HS uri by default.
-        return mHsUri;
+        return mHomeServerUri;
     }
 
     /**
@@ -168,7 +168,7 @@ public class HomeServerConnectionConfig {
     @Override
     public String toString() {
         return "HomeserverConnectionConfig{" +
-                "mHsUri=" + mHsUri +
+                "mHomeServerUri=" + mHomeServerUri +
                 ", mIdentityServerUri=" + mIdentityServerUri +
                 ", mAntiVirusServerUri=" + mAntiVirusServerUri +
                 ", mAllowedFingerprints size=" + mAllowedFingerprints.size() +
@@ -189,7 +189,7 @@ public class HomeServerConnectionConfig {
     public JSONObject toJson() throws JSONException {
         JSONObject json = new JSONObject();
 
-        json.put("home_server_url", mHsUri.toString());
+        json.put("home_server_url", mHomeServerUri.toString());
         json.put("identity_server_url", getIdentityServerUri().toString());
         if (mAntiVirusServerUri != null) {
             json.put("antivirus_server_url", mAntiVirusServerUri.toString());
@@ -317,24 +317,24 @@ public class HomeServerConnectionConfig {
         }
 
         /**
-         * @param hsUri The URI to use to connect to the homeserver. Cannot be null
+         * @param homeServerUri The URI to use to connect to the homeserver. Cannot be null
          * @return this builder
          */
-        public Builder withHomeServerUri(final Uri hsUri) {
-            if (hsUri == null || (!"http".equals(hsUri.getScheme()) && !"https".equals(hsUri.getScheme()))) {
-                throw new RuntimeException("Invalid home server URI: " + hsUri);
+        public Builder withHomeServerUri(final Uri homeServerUri) {
+            if (homeServerUri == null || (!"http".equals(homeServerUri.getScheme()) && !"https".equals(homeServerUri.getScheme()))) {
+                throw new RuntimeException("Invalid home server URI: " + homeServerUri);
             }
 
             // remove trailing /
-            if (hsUri.toString().endsWith("/")) {
+            if (homeServerUri.toString().endsWith("/")) {
                 try {
-                    String url = hsUri.toString();
-                    mHomeServerConnectionConfig.mHsUri = Uri.parse(url.substring(0, url.length() - 1));
+                    String url = homeServerUri.toString();
+                    mHomeServerConnectionConfig.mHomeServerUri = Uri.parse(url.substring(0, url.length() - 1));
                 } catch (Exception e) {
-                    throw new RuntimeException("Invalid home server URI: " + hsUri);
+                    throw new RuntimeException("Invalid home server URI: " + homeServerUri);
                 }
             } else {
-                mHomeServerConnectionConfig.mHsUri = hsUri;
+                mHomeServerConnectionConfig.mHomeServerUri = homeServerUri;
             }
 
             return this;
@@ -512,7 +512,7 @@ public class HomeServerConnectionConfig {
          */
         public HomeServerConnectionConfig build() {
             // Check mandatory parameters
-            if (mHomeServerConnectionConfig.mHsUri == null) {
+            if (mHomeServerConnectionConfig.mHomeServerUri == null) {
                 throw new RuntimeException("Home server URI not set");
             }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
@@ -196,17 +196,18 @@ public class RestClient<T> {
             okHttpClientBuilder.dispatcher(new Dispatcher(new MXRestExecutorService()));
         }
 
+        final String endPoint = makeEndpoint(hsConfig, uriPrefix, endPointServer);
+
         try {
             Pair<SSLSocketFactory, X509TrustManager> pair = CertUtil.newPinnedSSLSocketFactory(hsConfig);
             okHttpClientBuilder.sslSocketFactory(pair.first, pair.second);
             okHttpClientBuilder.hostnameVerifier(CertUtil.newHostnameVerifier(hsConfig));
-            okHttpClientBuilder.connectionSpecs(CertUtil.newConnectionSpecs(hsConfig));
+            okHttpClientBuilder.connectionSpecs(CertUtil.newConnectionSpecs(hsConfig, endPoint));
         } catch (Exception e) {
             Log.e(LOG_TAG, "## RestClient() setSslSocketFactory failed: " + e.getMessage(), e);
         }
 
         mOkHttpClient = okHttpClientBuilder.build();
-        final String endPoint = makeEndpoint(hsConfig, uriPrefix, endPointServer);
 
         // Rest adapter for turning API interfaces into actual REST-calling objects
         Retrofit.Builder builder = new Retrofit.Builder()

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/ssl/CertUtil.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/ssl/CertUtil.java
@@ -17,6 +17,7 @@
 
 package org.matrix.androidsdk.ssl;
 
+import android.support.annotation.NonNull;
 import android.util.Pair;
 
 import org.matrix.androidsdk.HomeServerConnectionConfig;
@@ -253,9 +254,10 @@ public class CertUtil {
      * Create a list of accepted TLS specifications for a hs config.
      *
      * @param hsConfig the hs config.
+     * @param url      the url of the end point, used to check if we have to enable CLEARTEXT communication.
      * @return a list of accepted TLS specifications.
      */
-    public static List<ConnectionSpec> newConnectionSpecs(HomeServerConnectionConfig hsConfig) {
+    public static List<ConnectionSpec> newConnectionSpecs(@NonNull HomeServerConnectionConfig hsConfig, @NonNull String url) {
         final ConnectionSpec.Builder builder = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS);
 
         final List<TlsVersion> tlsVersions = hsConfig.getAcceptedTlsVersions();
@@ -274,7 +276,7 @@ public class CertUtil {
 
         list.add(builder.build());
 
-        if (hsConfig.isHttpConnectionAllowed()) {
+        if (url.startsWith("http://")) {
             list.add(ConnectionSpec.CLEARTEXT);
         }
 


### PR DESCRIPTION
Many users complain about there application becoming unusable because configured in a onion services environment or using a http server (see vector-im/riot-android#2495).

This PR enable CLEARTEXT only when the url starts with http.

@af-anssi can you please review my PR and confirm that it's acceptable from your point of view?

Thanks