### PR TITLE
Handle any AccountData element

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,14 @@ Features:
  -
 
 Improvements:
- -
+ - Any Account data element, even if the type is not known is persisted.
 
 Bugfix:
  -
 
 API Change:
  - new API in CallSoundsManager to allow client to play the specified Ringtone (vector-im/riot-android#827)
+ - IMXStore.storeAccountData() has been renamed to IMXStore.storeRoomAccountData()
 
 Translations:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
@@ -1025,7 +1025,7 @@ public class MXDataHandler {
      */
     private void managePushRulesUpdate(List<AccountDataElement> accountDataElements) {
         for (AccountDataElement accountDataElement : accountDataElements) {
-            if (TextUtils.equals(accountDataElement.type, AccountDataRestClient.ACCOUNT_DATA_TYPE_PUSH_RULES)) {
+            if (TextUtils.equals(accountDataElement.type, AccountDataElement.ACCOUNT_DATA_TYPE_PUSH_RULES)) {
                 Gson gson = JsonUtils.getGson(false);
 
                 // convert the data to PushRulesResponse
@@ -1079,9 +1079,9 @@ public class MXDataHandler {
         List<String> ignoredUsers = null;
 
         for (AccountDataElement accountDataElement : accountDataElements) {
-            if (TextUtils.equals(accountDataElement.type, AccountDataRestClient.ACCOUNT_DATA_TYPE_IGNORED_USER_LIST)) {
-                if (accountDataElement.content.containsKey(AccountDataRestClient.ACCOUNT_DATA_KEY_IGNORED_USERS)) {
-                    Map<String, Object> ignored_users = (Map<String, Object>) accountDataElement.content.get(AccountDataRestClient.ACCOUNT_DATA_KEY_IGNORED_USERS);
+            if (TextUtils.equals(accountDataElement.type, AccountDataElement.ACCOUNT_DATA_TYPE_IGNORED_USER_LIST)) {
+                if (accountDataElement.content.containsKey(AccountDataElement.ACCOUNT_DATA_KEY_IGNORED_USERS)) {
+                    Map<String, Object> ignored_users = (Map<String, Object>) accountDataElement.content.get(AccountDataElement.ACCOUNT_DATA_KEY_IGNORED_USERS);
 
                     if (null != ignored_users) {
                         ignoredUsers = new ArrayList<>(ignored_users.keySet());
@@ -1101,7 +1101,7 @@ public class MXDataHandler {
      */
     private void manageDirectChatRooms(List<AccountDataElement> accountDataElements, boolean isInitialSync) {
         for (AccountDataElement accountDataElement : accountDataElements) {
-            if (TextUtils.equals(accountDataElement.type, AccountDataRestClient.ACCOUNT_DATA_TYPE_DIRECT_MESSAGES)) {
+            if (TextUtils.equals(accountDataElement.type, AccountDataElement.ACCOUNT_DATA_TYPE_DIRECT_MESSAGES)) {
                 Log.d(LOG_TAG, "## manageDirectChatRooms() : update direct chats map" + accountDataElement.content);
 
                 Gson gson = JsonUtils.getGson(false);
@@ -1131,13 +1131,13 @@ public class MXDataHandler {
      */
     private void manageUrlPreview(List<AccountDataElement> accountDataElements) {
         for (AccountDataElement accountDataElement : accountDataElements) {
-            if (TextUtils.equals(accountDataElement.type, AccountDataRestClient.ACCOUNT_DATA_TYPE_PREVIEW_URLS)) {
+            if (TextUtils.equals(accountDataElement.type, AccountDataElement.ACCOUNT_DATA_TYPE_PREVIEW_URLS)) {
                 Map<String, Object> contentDict = accountDataElement.content;
 
                 Log.d(LOG_TAG, "## manageUrlPreview() : " + contentDict);
                 boolean enable = true;
-                if (contentDict.containsKey(AccountDataRestClient.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE)) {
-                    enable = !((boolean) contentDict.get(AccountDataRestClient.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE));
+                if (contentDict.containsKey(AccountDataElement.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE)) {
+                    enable = !((boolean) contentDict.get(AccountDataElement.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE));
                 }
 
                 mStore.setURLPreviewEnabled(enable);
@@ -1152,7 +1152,7 @@ public class MXDataHandler {
      */
     private void manageUserWidgets(List<AccountDataElement> accountDataElements) {
         for (AccountDataElement accountDataElement : accountDataElements) {
-            if (TextUtils.equals(accountDataElement.type, AccountDataRestClient.ACCOUNT_DATA_TYPE_WIDGETS)) {
+            if (TextUtils.equals(accountDataElement.type, AccountDataElement.ACCOUNT_DATA_TYPE_WIDGETS)) {
                 Map<String, Object> contentDict = accountDataElement.content;
 
                 Log.d(LOG_TAG, "## manageUserWidgets() : " + contentDict);
@@ -1417,7 +1417,7 @@ public class MXDataHandler {
 
                     if (hasChanged) {
                         // Update account data to add new direct chat room(s)
-                        mAccountDataRestClient.setAccountData(mCredentials.userId, AccountDataRestClient.ACCOUNT_DATA_TYPE_DIRECT_MESSAGES,
+                        mAccountDataRestClient.setAccountData(mCredentials.userId, AccountDataElement.ACCOUNT_DATA_TYPE_DIRECT_MESSAGES,
                                 updatedDirectChatRoomsDict, new ApiCallback<Void>() {
                                     @Override
                                     public void onSuccess(Void info) {
@@ -2081,7 +2081,7 @@ public class MXDataHandler {
         }
         mLocalDirectChatRoomIdsList = null;
         // Upload the new map
-        mAccountDataRestClient.setAccountData(getMyUser().user_id, AccountDataRestClient.ACCOUNT_DATA_TYPE_DIRECT_MESSAGES, directChatRoomsMap, callback);
+        mAccountDataRestClient.setAccountData(getMyUser().user_id, AccountDataElement.ACCOUNT_DATA_TYPE_DIRECT_MESSAGES, directChatRoomsMap, callback);
     }
 
     /**

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
@@ -1049,7 +1049,16 @@ public class MXDataHandler {
      * @param accountDataElement the account data element of correct type
      */
     private void manageIgnoredUsers(AccountDataElement accountDataElement, boolean isInitialSync) {
-        List<String> newIgnoredUsers = ignoredUsers(accountDataElement);
+        List<String> newIgnoredUsers = null;
+
+        // Extract the ignored users list from the account data events list.
+        if (accountDataElement.content.containsKey(AccountDataElement.ACCOUNT_DATA_KEY_IGNORED_USERS)) {
+            Map<String, Object> ignored_users = (Map<String, Object>) accountDataElement.content.get(AccountDataElement.ACCOUNT_DATA_KEY_IGNORED_USERS);
+
+            if (null != ignored_users) {
+                newIgnoredUsers = new ArrayList<>(ignored_users.keySet());
+            }
+        }
 
         if (null != newIgnoredUsers) {
             List<String> curIgnoredUsers = getIgnoredUserIds();
@@ -1070,27 +1079,6 @@ public class MXDataHandler {
             }
         }
     }
-
-    /**
-     * Extract the ignored users list from the account data events list..
-     *
-     * @param accountDataElement the account data element of correct type
-     * @return the ignored users list. null means that there is no defined user ids list.
-     */
-    private List<String> ignoredUsers(AccountDataElement accountDataElement) {
-        List<String> ignoredUsers = null;
-
-        if (accountDataElement.content.containsKey(AccountDataElement.ACCOUNT_DATA_KEY_IGNORED_USERS)) {
-            Map<String, Object> ignored_users = (Map<String, Object>) accountDataElement.content.get(AccountDataElement.ACCOUNT_DATA_KEY_IGNORED_USERS);
-
-            if (null != ignored_users) {
-                ignoredUsers = new ArrayList<>(ignored_users.keySet());
-            }
-        }
-
-        return ignoredUsers;
-    }
-
 
     /**
      * Extract the direct chat rooms list from the dedicated events.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
@@ -1031,7 +1031,7 @@ public class MXDataHandler {
         for (Map<String, Object> event : events) {
             String type = (String) event.get("type");
 
-            if (TextUtils.equals(type, "m.push_rules")) {
+            if (TextUtils.equals(type, AccountDataRestClient.ACCOUNT_DATA_TYPE_PUSH_RULES)) {
                 if (event.containsKey("content")) {
                     Gson gson = JsonUtils.getGson(false);
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
@@ -1313,6 +1313,11 @@ public class MXDataHandler {
                     && !syncResponse.accountData.accountDataElements.isEmpty()) {
                 Log.d(LOG_TAG, "Received " + syncResponse.accountData.accountDataElements.size() + " accountData events");
                 manageAccountData(syncResponse.accountData.accountDataElements, isInitialSync);
+
+                // Global management, to be sure to handle any account data
+                getStore().storeAccountData(syncResponse.accountData);
+
+                mMxEventDispatcher.dispatchOnAccountDataUpdate();
             }
 
             // sanity check

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -86,6 +86,7 @@ import org.matrix.androidsdk.rest.model.pid.DeleteDeviceAuth;
 import org.matrix.androidsdk.rest.model.pid.DeleteDeviceParams;
 import org.matrix.androidsdk.rest.model.search.SearchResponse;
 import org.matrix.androidsdk.rest.model.search.SearchUsersResponse;
+import org.matrix.androidsdk.rest.model.sync.AccountDataElement;
 import org.matrix.androidsdk.rest.model.sync.DevicesListResponse;
 import org.matrix.androidsdk.rest.model.sync.RoomResponse;
 import org.matrix.androidsdk.sync.DefaultEventsThreadListener;
@@ -1940,9 +1941,9 @@ public class MXSession {
         }
 
         Map<String, Object> params = new HashMap<>();
-        params.put(AccountDataRestClient.ACCOUNT_DATA_KEY_IGNORED_USERS, ignoredUsersDict);
+        params.put(AccountDataElement.ACCOUNT_DATA_KEY_IGNORED_USERS, ignoredUsersDict);
 
-        mAccountDataRestClient.setAccountData(getMyUserId(), AccountDataRestClient.ACCOUNT_DATA_TYPE_IGNORED_USER_LIST, params, callback);
+        mAccountDataRestClient.setAccountData(getMyUserId(), AccountDataElement.ACCOUNT_DATA_TYPE_IGNORED_USER_LIST, params, callback);
     }
 
     /**
@@ -2143,10 +2144,10 @@ public class MXSession {
      */
     public void setURLPreviewStatus(final boolean status, final ApiCallback<Void> callback) {
         Map<String, Object> params = new HashMap<>();
-        params.put(AccountDataRestClient.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE, !status);
+        params.put(AccountDataElement.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE, !status);
 
         Log.d(LOG_TAG, "## setURLPreviewStatus() : status " + status);
-        mAccountDataRestClient.setAccountData(getMyUserId(), AccountDataRestClient.ACCOUNT_DATA_TYPE_PREVIEW_URLS, params, new ApiCallback<Void>() {
+        mAccountDataRestClient.setAccountData(getMyUserId(), AccountDataElement.ACCOUNT_DATA_TYPE_PREVIEW_URLS, params, new ApiCallback<Void>() {
             @Override
             public void onSuccess(Void info) {
                 Log.d(LOG_TAG, "## setURLPreviewStatus() : succeeds");
@@ -2186,7 +2187,7 @@ public class MXSession {
     public void addUserWidget(final Map<String, Object> params, final ApiCallback<Void> callback) {
         Log.d(LOG_TAG, "## addUserWidget()");
 
-        mAccountDataRestClient.setAccountData(getMyUserId(), AccountDataRestClient.ACCOUNT_DATA_TYPE_WIDGETS, params, new ApiCallback<Void>() {
+        mAccountDataRestClient.setAccountData(getMyUserId(), AccountDataElement.ACCOUNT_DATA_TYPE_WIDGETS, params, new ApiCallback<Void>() {
             @Override
             public void onSuccess(Void info) {
                 Log.d(LOG_TAG, "## addUserWidget() : succeeds");

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -526,6 +526,11 @@ public class MXSession {
         return mMediaScanRestClient;
     }
 
+    public AccountDataRestClient getAccountDataRestClient() {
+        checkIfAlive();
+        return mAccountDataRestClient;
+    }
+
     protected void setEventsApiClient(EventsRestClient eventsRestClient) {
         checkIfAlive();
         mEventsRestClient = eventsRestClient;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MxEventDispatcher.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MxEventDispatcher.java
@@ -719,6 +719,23 @@ import java.util.Set;
         });
     }
 
+    public void dispatchOnAccountDataUpdate() {
+        final List<IMXEventListener> eventListeners = getListenersSnapshot();
+
+        mUiHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                for (IMXEventListener listener : eventListeners) {
+                    try {
+                        listener.onAccountDataUpdated();
+                    } catch (Exception e) {
+                        Log.e(LOG_TAG, "onAccountDataUpdated " + e.getMessage(), e);
+                    }
+                }
+            }
+        });
+    }
+
     /* ==========================================================================================
      * Private
      * ========================================================================================== */

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/RestClient.java
@@ -160,25 +160,11 @@ public class RestClient<T> {
             }
         };
 
-        // TODO Remove this, seems so useless
-        Interceptor connectivityInterceptor = new Interceptor() {
-            @Override
-            public Response intercept(Chain chain) throws IOException {
-                if (mUnsentEventsManager != null
-                        && mUnsentEventsManager.getNetworkConnectivityReceiver() != null
-                        && !mUnsentEventsManager.getNetworkConnectivityReceiver().isConnected()) {
-                    throw new IOException("Not connected");
-                }
-                return chain.proceed(chain.request());
-            }
-        };
-
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient().newBuilder()
                 .connectTimeout(CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .writeTimeout(WRITE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                .addInterceptor(authentInterceptor)
-                .addInterceptor(connectivityInterceptor);
+                .addInterceptor(authentInterceptor);
 
         if (BuildConfig.DEBUG) {
             HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(new FormattedJsonHttpLogger());

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -1940,7 +1940,7 @@ public class Room {
             }
 
             if (null != getStore()) {
-                getStore().storeAccountData(getRoomId(), mAccountData);
+                getStore().storeRoomAccountData(getRoomId(), mAccountData);
             }
         }
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -53,7 +53,6 @@ import org.matrix.androidsdk.listeners.MXEventListener;
 import org.matrix.androidsdk.listeners.MXRoomEventListener;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
-import org.matrix.androidsdk.rest.client.AccountDataRestClient;
 import org.matrix.androidsdk.rest.client.RoomsRestClient;
 import org.matrix.androidsdk.rest.client.UrlPostTask;
 import org.matrix.androidsdk.rest.model.CreatedEvent;
@@ -74,6 +73,7 @@ import org.matrix.androidsdk.rest.model.message.Message;
 import org.matrix.androidsdk.rest.model.message.ThumbnailInfo;
 import org.matrix.androidsdk.rest.model.message.VideoInfo;
 import org.matrix.androidsdk.rest.model.message.VideoMessage;
+import org.matrix.androidsdk.rest.model.sync.AccountDataElement;
 import org.matrix.androidsdk.rest.model.sync.InvitedRoomSync;
 import org.matrix.androidsdk.rest.model.sync.RoomResponse;
 import org.matrix.androidsdk.rest.model.sync.RoomSync;
@@ -1924,8 +1924,8 @@ public class Room {
                         mDataHandler.onRoomTagEvent(getRoomId());
                     } else if (Event.EVENT_TYPE_URL_PREVIEW.equals(accountDataEvent.getType())) {
                         final JsonObject jsonObject = accountDataEvent.getContentAsJsonObject();
-                        if (jsonObject.has(AccountDataRestClient.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE)) {
-                            final boolean disabled = jsonObject.get(AccountDataRestClient.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE).getAsBoolean();
+                        if (jsonObject.has(AccountDataElement.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE)) {
+                            final boolean disabled = jsonObject.get(AccountDataElement.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE).getAsBoolean();
                             Set<String> roomIdsWithoutURLPreview = mDataHandler.getStore().getRoomsWithoutURLPreviews();
                             if (disabled) {
                                 roomIdsWithoutURLPreview.add(getRoomId());

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -329,7 +329,7 @@ public class Room {
                     Log.d(LOG_TAG, "## handleJoinedRoomSync : received " + roomSync.accountData.events.size() + " account data events");
                 }
 
-                handleAccountDataEvents(roomSync.accountData.events);
+                handleRoomAccountDataEvents(roomSync.accountData.events);
             }
         }
 
@@ -1896,7 +1896,7 @@ public class Room {
      *
      * @param accountDataEvents the account events.
      */
-    private void handleAccountDataEvents(List<Event> accountDataEvents) {
+    private void handleRoomAccountDataEvents(List<Event> accountDataEvents) {
         if ((null != accountDataEvents) && (accountDataEvents.size() > 0)) {
             // manage the account events
             for (Event accountDataEvent : accountDataEvents) {
@@ -1907,9 +1907,9 @@ public class Room {
                     if (summary != null) {
                         final Event event = JsonUtils.toEvent(accountDataEvent.getContent());
                         if (null != event && !TextUtils.equals(event.eventId, summary.getReadMarkerEventId())) {
-                            Log.d(LOG_TAG, "## handleAccountDataEvents() : update the read marker to " + event.eventId + " in room " + getRoomId());
+                            Log.d(LOG_TAG, "## handleRoomAccountDataEvents() : update the read marker to " + event.eventId + " in room " + getRoomId());
                             if (TextUtils.isEmpty(event.eventId)) {
-                                Log.e(LOG_TAG, "## handleAccountDataEvents() : null event id " + accountDataEvent.getContent());
+                                Log.e(LOG_TAG, "## handleRoomAccountDataEvents() : null event id " + accountDataEvent.getContent());
                             }
                             summary.setReadMarkerEventId(event.eventId);
                             getStore().flushSummary(summary);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/store/IMXStore.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/store/IMXStore.java
@@ -21,11 +21,11 @@ package org.matrix.androidsdk.data.store;
 import android.content.Context;
 import android.support.annotation.Nullable;
 
-import org.matrix.androidsdk.data.timeline.EventTimeline;
 import org.matrix.androidsdk.data.Room;
 import org.matrix.androidsdk.data.RoomAccountData;
 import org.matrix.androidsdk.data.RoomSummary;
 import org.matrix.androidsdk.data.metrics.MetricsListener;
+import org.matrix.androidsdk.data.timeline.EventTimeline;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.ReceiptData;
@@ -34,6 +34,8 @@ import org.matrix.androidsdk.rest.model.TokensChunkEvents;
 import org.matrix.androidsdk.rest.model.User;
 import org.matrix.androidsdk.rest.model.group.Group;
 import org.matrix.androidsdk.rest.model.pid.ThirdPartyIdentifier;
+import org.matrix.androidsdk.rest.model.sync.AccountData;
+import org.matrix.androidsdk.rest.model.sync.AccountDataElement;
 
 import java.util.Collection;
 import java.util.List;
@@ -517,12 +519,25 @@ public interface IMXStore {
     boolean isEventRead(String roomId, String userId, String eventId);
 
     /**
+     * Store the user account data.
+     *
+     * @param accountData the account data, or a partial account data in case of account data update
+     */
+    void storeAccountData(AccountData accountData);
+
+    /**
+     * Get Account Data value for the corresponding type, or null if not found
+     */
+    @Nullable
+    AccountDataElement getAccountDataElement(String type);
+
+    /**
      * Store the user data for a room.
      *
      * @param roomId      The room Id.
      * @param accountData the account data.
      */
-    void storeAccountData(String roomId, RoomAccountData accountData);
+    void storeRoomAccountData(String roomId, RoomAccountData accountData);
 
     /**
      * Provides the store preload time in milliseconds.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/IMXEventListener.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/IMXEventListener.java
@@ -261,5 +261,10 @@ public interface IMXEventListener {
      * @param groupId the group id
      */
     void onGroupInvitedUsersListUpdate(String groupId);
+
+    /**
+     * Account data has been updated from the sync
+     */
+    void onAccountDataUpdated();
 }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/MXEventListener.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/MXEventListener.java
@@ -163,4 +163,8 @@ public class MXEventListener implements IMXEventListener {
     @Override
     public void onGroupInvitedUsersListUpdate(String groupId) {
     }
+
+    @Override
+    public void onAccountDataUpdated() {
+    }
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/AccountDataRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/AccountDataRestClient.java
@@ -27,21 +27,6 @@ import java.util.Map;
 
 public class AccountDataRestClient extends RestClient<AccountDataApi> {
     /**
-     * Account data known types
-     */
-    public static final String ACCOUNT_DATA_TYPE_IGNORED_USER_LIST = "m.ignored_user_list";
-    public static final String ACCOUNT_DATA_TYPE_DIRECT_MESSAGES = "m.direct";
-    public static final String ACCOUNT_DATA_TYPE_PREVIEW_URLS = "org.matrix.preview_urls";
-    public static final String ACCOUNT_DATA_TYPE_WIDGETS = "m.widgets";
-    public static final String ACCOUNT_DATA_TYPE_PUSH_RULES = "m.push_rules";
-
-    /**
-     * Account data keys
-     */
-    public static final String ACCOUNT_DATA_KEY_IGNORED_USERS = "ignored_users";
-    public static final String ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE = "disable";
-
-    /**
      * {@inheritDoc}
      */
     public AccountDataRestClient(HomeServerConnectionConfig hsConfig) {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/AccountDataRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/AccountDataRestClient.java
@@ -27,12 +27,13 @@ import java.util.Map;
 
 public class AccountDataRestClient extends RestClient<AccountDataApi> {
     /**
-     * Account data types
+     * Account data known types
      */
     public static final String ACCOUNT_DATA_TYPE_IGNORED_USER_LIST = "m.ignored_user_list";
     public static final String ACCOUNT_DATA_TYPE_DIRECT_MESSAGES = "m.direct";
     public static final String ACCOUNT_DATA_TYPE_PREVIEW_URLS = "org.matrix.preview_urls";
     public static final String ACCOUNT_DATA_TYPE_WIDGETS = "m.widgets";
+    public static final String ACCOUNT_DATA_TYPE_PUSH_RULES = "m.push_rules";
 
     /**
      * Account data keys
@@ -62,11 +63,11 @@ public class AccountDataRestClient extends RestClient<AccountDataApi> {
 
         mApi.setAccountData(userId, type, params)
                 .enqueue(new RestAdapterCallback<Void>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
-            @Override
-            public void onRetry() {
-                setAccountData(userId, type, params, callback);
-            }
-        }));
+                    @Override
+                    public void onRetry() {
+                        setAccountData(userId, type, params, callback);
+                    }
+                }));
     }
 
     /**
@@ -82,11 +83,11 @@ public class AccountDataRestClient extends RestClient<AccountDataApi> {
 
         mApi.openIdToken(userId, new HashMap<>())
                 .enqueue(new RestAdapterCallback<Map<Object, Object>>(description, mUnsentEventsManager, callback,
-                new RestAdapterCallback.RequestRetryCallBack() {
-            @Override
-            public void onRetry() {
-                openIdToken(userId, callback);
-            }
-        }));
+                        new RestAdapterCallback.RequestRetryCallBack() {
+                            @Override
+                            public void onRetry() {
+                                openIdToken(userId, callback);
+                            }
+                        }));
     }
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/RoomsRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/RoomsRestClient.java
@@ -49,6 +49,7 @@ import org.matrix.androidsdk.rest.model.User;
 import org.matrix.androidsdk.rest.model.UserIdAndReason;
 import org.matrix.androidsdk.rest.model.filter.RoomEventFilter;
 import org.matrix.androidsdk.rest.model.message.Message;
+import org.matrix.androidsdk.rest.model.sync.AccountDataElement;
 import org.matrix.androidsdk.rest.model.sync.RoomResponse;
 
 import java.util.HashMap;
@@ -892,7 +893,7 @@ public class RoomsRestClient extends RestClient<RoomsApi> {
         final String description = "updateURLPreviewStatus : roomId " + roomId + " - status " + status;
 
         Map<String, Object> params = new HashMap<>();
-        params.put(AccountDataRestClient.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE, !status);
+        params.put(AccountDataElement.ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE, !status);
 
         mApi.updateAccountData(getCredentials().userId, roomId, Event.EVENT_TYPE_URL_PREVIEW, params)
                 .enqueue(new RestAdapterCallback<Void>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -93,13 +93,15 @@ public class Event implements Externalizable {
     public static final String EVENT_TYPE_TYPING = "m.typing";
     public static final String EVENT_TYPE_REDACTION = "m.room.redaction";
     public static final String EVENT_TYPE_RECEIPT = "m.receipt";
-    public static final String EVENT_TYPE_TAGS = "m.tag";
     public static final String EVENT_TYPE_ROOM_KEY = "m.room_key";
-    public static final String EVENT_TYPE_READ_MARKER = "m.fully_read";
     public static final String EVENT_TYPE_ROOM_PLUMBING = "m.room.plumbing";
     public static final String EVENT_TYPE_ROOM_BOT_OPTIONS = "m.room.bot.options";
     public static final String EVENT_TYPE_ROOM_KEY_REQUEST = "m.room_key_request";
     public static final String EVENT_TYPE_FORWARDED_ROOM_KEY = "m.forwarded_room_key";
+
+    // Possible value for room account data type
+    public static final String EVENT_TYPE_TAGS = "m.tag";
+    public static final String EVENT_TYPE_READ_MARKER = "m.fully_read";
     public static final String EVENT_TYPE_URL_PREVIEW = "org.matrix.room.preview_urls";
 
     // State events

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountData.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountData.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk.rest.model.sync;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class AccountData implements Serializable {
+
+    @SerializedName("events")
+    public List<AccountDataElement> accountDataElements;
+
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountDataElement.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountDataElement.java
@@ -21,8 +21,24 @@ import java.util.Map;
 
 // It's a LightEvent
 public class AccountDataElement implements Serializable {
+    /**
+     * Account data known possible values for {@link #type}
+     */
+    public static final String ACCOUNT_DATA_TYPE_IGNORED_USER_LIST = "m.ignored_user_list";
+    public static final String ACCOUNT_DATA_TYPE_DIRECT_MESSAGES = "m.direct";
+    public static final String ACCOUNT_DATA_TYPE_PREVIEW_URLS = "org.matrix.preview_urls";
+    public static final String ACCOUNT_DATA_TYPE_WIDGETS = "m.widgets";
+    public static final String ACCOUNT_DATA_TYPE_PUSH_RULES = "m.push_rules";
 
+    /**
+     * Account data known possible values for key in {@link #content}
+     */
+    public static final String ACCOUNT_DATA_KEY_IGNORED_USERS = "ignored_users";
+    public static final String ACCOUNT_DATA_KEY_URL_PREVIEW_DISABLE = "disable";
+
+    // Type of account data element
     public String type;
 
+    // Content of account data element
     public Map<String, Object> content;
 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountDataElement.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountDataElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk.rest.model.sync;
+
+import java.io.Serializable;
+import java.util.Map;
+
+// It's a LightEvent
+public class AccountDataElement implements Serializable {
+
+    public String type;
+
+    public Map<String, Object> content;
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/SyncResponse.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/SyncResponse.java
@@ -20,15 +20,13 @@ package org.matrix.androidsdk.rest.model.sync;
 
 import org.matrix.androidsdk.rest.model.group.GroupsSyncResponse;
 
-import java.util.Map;
-
 // SyncResponse represents the request response for server sync v2.
 public class SyncResponse {
 
     /**
      * The user private data.
      */
-    public Map<String, Object> accountData;
+    public AccountData accountData;
 
     /**
      * The opaque token for the end.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/BingRulesManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/BingRulesManager.java
@@ -360,8 +360,7 @@ public class BingRulesManager {
         if (TextUtils.equals(eventType, Event.EVENT_TYPE_PRESENCE)
                 || TextUtils.equals(eventType, Event.EVENT_TYPE_TYPING)
                 || TextUtils.equals(eventType, Event.EVENT_TYPE_REDACTION)
-                || TextUtils.equals(eventType, Event.EVENT_TYPE_RECEIPT)
-                || TextUtils.equals(eventType, Event.EVENT_TYPE_TAGS)) {
+                || TextUtils.equals(eventType, Event.EVENT_TYPE_RECEIPT)) {
             return null;
         }
 


### PR DESCRIPTION
Any Account data element, even if the type is not known is persisted. So they can be accessed at any time using the new API getAccountDataElement(). If AccountData is updated (from any device logged on the same account), IMXEventListener.onAccountDataUpdated() will be called.

This PR also removes a useless check on network connectivity. The OkHttp lib handle this properly.