### PR TITLE
Ignore all whitespace in recovery key

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,33 @@ Build:
 Test:
  -
 
+Changes to Matrix Android SDK in 0.9.16 (2018-12-20)
+=======================================================
+
+Features:
+ -
+
+Improvements:
+ - isValidRecoveryKey() ignores now all whitespace characters, not only spaces
+
+Bugfix:
+ -
+
+API Change:
+ -
+
+Translations:
+ -
+
+Others:
+ -
+
+Build:
+ -
+
+Test:
+ - New test for recovery key with newlines in it
+
 Changes to Matrix Android SDK in 0.9.14 (2018-12-13)
 =======================================================
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/util/RecoveryKey.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/util/RecoveryKey.kt
@@ -81,7 +81,7 @@ fun extractCurveKeyFromRecoveryKey(recoveryKey: String?): ByteArray? {
     }
 
     // Remove any space
-    val spaceFreeRecoveryKey = recoveryKey.replace(" ".toRegex(), "")
+    val spaceFreeRecoveryKey = recoveryKey.replace("""\s""".toRegex(), "")
 
     val b58DecodedKey = base58decode(spaceFreeRecoveryKey)
 

--- a/matrix-sdk/src/test/java/org/matrix/androidsdk/crypto/util/RecoveryKeyTest.kt
+++ b/matrix-sdk/src/test/java/org/matrix/androidsdk/crypto/util/RecoveryKeyTest.kt
@@ -32,6 +32,9 @@ class RecoveryKeyTest {
 
         // Space should be ignored
         Assert.assertTrue(isValidRecoveryKey("EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d"))
+
+        // All whitespace should be ignored
+        Assert.assertTrue(isValidRecoveryKey("EsTc LW2K PGiF wKEA 3As5 g5c4\r\nBXwk qeeJ ZJV8 Q9fu gUMN UE4d"))
     }
 
     @Test


### PR DESCRIPTION
### Rationale

If the user copies his recovery key in another document, exports it to a PDF file, etc, there might be additional whitespace characters inserted. If he would copy this key and paste in the app to restore his backup, this additional whitespace characters should be ignored. 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [✔️] Pull request is based on the develop branch
* [✔️] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-android-sdk/blob/develop/CHANGES.rst)
* [✔️] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Signed-off-by: Martin Kamleithner martin@diagnosia.com

