### PR TITLE
do not attempt to serialize unserializable fields on MatrixError in E…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  -
 
 Bugfix:
- -  do not attempt to serialize unserializable fields on MatrixError in Event::writeExternal
+ -  remove unserializable fields in MatrixError
 
 API Change:
  -

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  -
 
 Bugfix:
- -
+ -  do not attempt to serialize unserializable fields on MatrixError in Event::writeExternal
 
 API Change:
  -
@@ -17,7 +17,7 @@ Translations:
  -
 
 Others:
- -
+ - fix typo in CHANGES.rst (wrong year)
 
 Build:
  -
@@ -25,7 +25,7 @@ Build:
 Test:
  -
 
-Changes to Matrix Android SDK in 0.9.15 (2018-01-02)
+Changes to Matrix Android SDK in 0.9.15 (2019-01-02)
 =======================================================
 
 Improvements:

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/callback/RestAdapterCallback.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/callback/RestAdapterCallback.java
@@ -234,8 +234,6 @@ public class RestAdapterCallback<T> implements Callback<T> {
 
                     mxError.mStatus = response.code();
                     mxError.mReason = response.message();
-                    mxError.mErrorBodyMimeType = errorBody.contentType();
-                    mxError.mErrorBody = errorBody;
                     mxError.mErrorBodyAsString = bodyAsString;
                 } catch (Exception e) {
                     mxError = null;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -54,6 +54,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+
 /**
  * Generic event class with all possible fields for events.
  */
@@ -1003,7 +1006,14 @@ public class Event implements Externalizable {
 
         output.writeBoolean(null != unsentMatrixError);
         if (null != unsentMatrixError) {
+            //dont write some instance variable because they're not serializable
+            ResponseBody notSerializableBody = unsentMatrixError.mErrorBody;
+            MediaType notSerializableMimeType = unsentMatrixError.mErrorBodyMimeType;
+            unsentMatrixError.mErrorBody = null;
+            unsentMatrixError.mErrorBodyMimeType = null;
             output.writeObject(unsentMatrixError);
+            unsentMatrixError.mErrorBody = notSerializableBody;
+            unsentMatrixError.mErrorBodyMimeType = notSerializableMimeType;
         }
 
         output.writeObject(mSentState);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -1006,14 +1006,7 @@ public class Event implements Externalizable {
 
         output.writeBoolean(null != unsentMatrixError);
         if (null != unsentMatrixError) {
-            //dont write some instance variable because they're not serializable
-            ResponseBody notSerializableBody = unsentMatrixError.mErrorBody;
-            MediaType notSerializableMimeType = unsentMatrixError.mErrorBodyMimeType;
-            unsentMatrixError.mErrorBody = null;
-            unsentMatrixError.mErrorBodyMimeType = null;
             output.writeObject(unsentMatrixError);
-            unsentMatrixError.mErrorBody = notSerializableBody;
-            unsentMatrixError.mErrorBodyMimeType = notSerializableMimeType;
         }
 
         output.writeObject(mSentState);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -54,8 +54,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
-import okhttp3.MediaType;
-import okhttp3.ResponseBody;
+
 
 /**
  * Generic event class with all possible fields for events.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/MatrixError.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/MatrixError.java
@@ -87,9 +87,7 @@ public class MatrixError implements java.io.Serializable {
     // extracted from the error response
     public Integer mStatus;
     public String mReason;
-    public ResponseBody mErrorBody;
     public String mErrorBodyAsString;
-    public MediaType mErrorBodyMimeType;
 
     /**
      * Default creator


### PR DESCRIPTION
…vent::writeExternal

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* ✅ Pull request is based on the develop branch
* ✅ Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-android-sdk/blob/develop/CHANGES.rst)
* ✅ Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)

Currently, serializing Events that have a MatrixError set fails with a 
`java.io.NotSerializableException: okhttp3.ResponseBody$1` Exception.

It seems that this means, that the sending won't be retried later. 
This fixes the exception, by stripping the event of all non-serializable fields before serialing, and then setting the fields again to cause no side-effects to the object. 

This could also be done using transient, but since there are other types of serialization (Gson, Realm) in the project I thought this approach is less likely to break anything. 
If using transient is acceptable, I'll update my pull request.

Signed-off-by: Martin Kamleithner martin@diagnosia.com