### PR TITLE
Improve performance of keys importation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Features:
  -
 
 Improvements:
- -
+ - Improve import of keys performance (vector-im/riot-android#2960)
 
 Bugfix:
  -

--- a/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/CryptoTest.java
+++ b/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/CryptoTest.java
@@ -2498,13 +2498,16 @@ public class CryptoTest {
         // test with a wrong password
         CountDownLatch lock3 = new CountDownLatch(1);
         aliceSession2.getCrypto()
-                .importRoomKeys((byte[]) results.get("exportRoomKeys"), "wrong password", new TestApiCallback<ImportRoomKeysResult>(lock3, false) {
-                    @Override
-                    public void onUnexpectedError(Exception e) {
-                        results.put("importRoomKeys_failed", "importRoomKeys_failed");
-                        super.onUnexpectedError(e);
-                    }
-                });
+                .importRoomKeys((byte[]) results.get("exportRoomKeys"),
+                        "wrong password",
+                        null,
+                        new TestApiCallback<ImportRoomKeysResult>(lock3, false) {
+                            @Override
+                            public void onUnexpectedError(Exception e) {
+                                results.put("importRoomKeys_failed", "importRoomKeys_failed");
+                                super.onUnexpectedError(e);
+                            }
+                        });
         mTestHelper.await(lock3);
         Assert.assertTrue(results.containsKey("importRoomKeys_failed"));
 
@@ -2517,16 +2520,19 @@ public class CryptoTest {
         Assert.assertEquals(MXCryptoError.UNKNOWN_INBOUND_SESSION_ID_ERROR_CODE, event.getCryptoError().errcode);
 
         CountDownLatch lock4 = new CountDownLatch(1);
-        aliceSession2.getCrypto().importRoomKeys((byte[]) results.get("exportRoomKeys"), password, new TestApiCallback<ImportRoomKeysResult>(lock4) {
-            @Override
-            public void onSuccess(ImportRoomKeysResult info) {
-                Assert.assertEquals(1, info.getTotalNumberOfKeys());
-                Assert.assertEquals(1, info.getSuccessfullyNumberOfImportedKeys());
+        aliceSession2.getCrypto().importRoomKeys((byte[]) results.get("exportRoomKeys"),
+                password,
+                null,
+                new TestApiCallback<ImportRoomKeysResult>(lock4) {
+                    @Override
+                    public void onSuccess(ImportRoomKeysResult info) {
+                        Assert.assertEquals(1, info.getTotalNumberOfKeys());
+                        Assert.assertEquals(1, info.getSuccessfullyNumberOfImportedKeys());
 
-                results.put("importRoomKeys", "importRoomKeys");
-                super.onSuccess(info);
-            }
-        });
+                        results.put("importRoomKeys", "importRoomKeys");
+                        super.onSuccess(info);
+                    }
+                });
         mTestHelper.await(lock4);
         Assert.assertTrue(results.containsKey("importRoomKeys"));
 

--- a/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupTest.kt
+++ b/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupTest.kt
@@ -342,7 +342,7 @@ class KeysBackupTest {
         // - Restore the e2e backup from the homeserver
         val latch2 = CountDownLatch(1)
         var importRoomKeysResult: ImportRoomKeysResult? = null
-        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.prepareKeysBackupDataResult.version,
+        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion!!,
                 testData.prepareKeysBackupDataResult.megolmBackupCreationInfo.recoveryKey,
                 null,
                 null,
@@ -379,7 +379,6 @@ class KeysBackupTest {
 
         val testData = createKeysBackupScenarioWithPassword(null)
 
-
         // - Check the SDK sent key share requests
         val unsentRequest = testData.aliceSession2.crypto?.cryptoStore
                 ?.getOutgoingRoomKeyRequestByState(setOf(OutgoingRoomKeyRequest.RequestState.UNSENT))
@@ -392,7 +391,7 @@ class KeysBackupTest {
         // - Restore the e2e backup from the homeserver
         val latch2 = CountDownLatch(1)
         var importRoomKeysResult: ImportRoomKeysResult? = null
-        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.prepareKeysBackupDataResult.version,
+        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion!!,
                 testData.prepareKeysBackupDataResult.megolmBackupCreationInfo.recoveryKey,
                 null,
                 null,
@@ -437,12 +436,9 @@ class KeysBackupTest {
         // - And log Alice on a new device
         val context = InstrumentationRegistry.getContext()
 
-        val testData = createKeysBackupScenarioWithPassword(null, true)
+        val testData = createKeysBackupScenarioWithPassword(null)
 
         val stateObserver = StateObserver(testData.aliceSession2.crypto!!.keysBackup)
-
-        // Wait for backup state to be NotTrusted
-        waitForKeysBackupToBeInState(testData.aliceSession2, KeysBackupStateManager.KeysBackupState.NotTrusted)
 
         // - The new device must see the previous backup as not trusted
         assertNotNull(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion)
@@ -516,12 +512,9 @@ class KeysBackupTest {
         // - And log Alice on a new device
         val context = InstrumentationRegistry.getContext()
 
-        val testData = createKeysBackupScenarioWithPassword(null, true)
+        val testData = createKeysBackupScenarioWithPassword(null)
 
         val stateObserver = StateObserver(testData.aliceSession2.crypto!!.keysBackup)
-
-        // Wait for backup state to be NotTrusted
-        waitForKeysBackupToBeInState(testData.aliceSession2, KeysBackupStateManager.KeysBackupState.NotTrusted)
 
         // - The new device must see the previous backup as not trusted
         assertNotNull(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion)
@@ -593,12 +586,9 @@ class KeysBackupTest {
         // - And log Alice on a new device
         val context = InstrumentationRegistry.getContext()
 
-        val testData = createKeysBackupScenarioWithPassword(null, true)
+        val testData = createKeysBackupScenarioWithPassword(null)
 
         val stateObserver = StateObserver(testData.aliceSession2.crypto!!.keysBackup)
-
-        // Wait for backup state to be NotTrusted
-        waitForKeysBackupToBeInState(testData.aliceSession2, KeysBackupStateManager.KeysBackupState.NotTrusted)
 
         // - The new device must see the previous backup as not trusted
         assertNotNull(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion)
@@ -641,12 +631,9 @@ class KeysBackupTest {
         // - And log Alice on a new device
         val context = InstrumentationRegistry.getContext()
 
-        val testData = createKeysBackupScenarioWithPassword(password, true)
+        val testData = createKeysBackupScenarioWithPassword(password)
 
         val stateObserver = StateObserver(testData.aliceSession2.crypto!!.keysBackup)
-
-        // Wait for backup state to be NotTrusted
-        waitForKeysBackupToBeInState(testData.aliceSession2, KeysBackupStateManager.KeysBackupState.NotTrusted)
 
         // - The new device must see the previous backup as not trusted
         assertNotNull(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion)
@@ -721,12 +708,9 @@ class KeysBackupTest {
         // - And log Alice on a new device
         val context = InstrumentationRegistry.getContext()
 
-        val testData = createKeysBackupScenarioWithPassword(password, true)
+        val testData = createKeysBackupScenarioWithPassword(password)
 
         val stateObserver = StateObserver(testData.aliceSession2.crypto!!.keysBackup)
-
-        // Wait for backup state to be NotTrusted
-        waitForKeysBackupToBeInState(testData.aliceSession2, KeysBackupStateManager.KeysBackupState.NotTrusted)
 
         // - The new device must see the previous backup as not trusted
         assertNotNull(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion)
@@ -766,7 +750,7 @@ class KeysBackupTest {
         // - Try to restore the e2e backup with a wrong recovery key
         val latch2 = CountDownLatch(1)
         var importRoomKeysResult: ImportRoomKeysResult? = null
-        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.prepareKeysBackupDataResult.version,
+        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion!!,
                 "EsTc LW2K PGiF wKEA 3As5 g5c4 BXwk qeeJ ZJV8 Q9fu gUMN UE4d",
                 null,
                 null,
@@ -805,7 +789,7 @@ class KeysBackupTest {
         var importRoomKeysResult: ImportRoomKeysResult? = null
         val steps = ArrayList<StepProgressListener.Step>()
 
-        testData.aliceSession2.crypto!!.keysBackup.restoreKeyBackupWithPassword(testData.prepareKeysBackupDataResult.version,
+        testData.aliceSession2.crypto!!.keysBackup.restoreKeyBackupWithPassword(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion!!,
                 password,
                 null,
                 null,
@@ -867,7 +851,7 @@ class KeysBackupTest {
         // - Try to restore the e2e backup with a wrong password
         val latch2 = CountDownLatch(1)
         var importRoomKeysResult: ImportRoomKeysResult? = null
-        testData.aliceSession2.crypto!!.keysBackup.restoreKeyBackupWithPassword(testData.prepareKeysBackupDataResult.version,
+        testData.aliceSession2.crypto!!.keysBackup.restoreKeyBackupWithPassword(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion!!,
                 wrongPassword,
                 null,
                 null,
@@ -904,7 +888,7 @@ class KeysBackupTest {
         // - Restore the e2e backup with the recovery key.
         val latch2 = CountDownLatch(1)
         var importRoomKeysResult: ImportRoomKeysResult? = null
-        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.prepareKeysBackupDataResult.version,
+        testData.aliceSession2.crypto!!.keysBackup.restoreKeysWithRecoveryKey(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion!!,
                 testData.prepareKeysBackupDataResult.megolmBackupCreationInfo.recoveryKey,
                 null,
                 null,
@@ -938,7 +922,7 @@ class KeysBackupTest {
         // - Try to restore the e2e backup with a password
         val latch2 = CountDownLatch(1)
         var importRoomKeysResult: ImportRoomKeysResult? = null
-        testData.aliceSession2.crypto!!.keysBackup.restoreKeyBackupWithPassword(testData.prepareKeysBackupDataResult.version,
+        testData.aliceSession2.crypto!!.keysBackup.restoreKeyBackupWithPassword(testData.aliceSession2.crypto!!.keysBackup.mKeysBackupVersion!!,
                 "password",
                 null,
                 null,
@@ -1363,13 +1347,14 @@ class KeysBackupTest {
 
                 version = info.version
 
-                // Backup must be enable now
-                assertTrue(keysBackup.isEnabled)
-
                 super.onSuccess(info)
             }
         })
         mTestHelper.await(latch2)
+
+        // Backup must be enable now
+        assertTrue(keysBackup.isEnabled)
+        assertNotNull(version)
 
         stateObserver.stopAndCheckStates(null)
         return PrepareKeysBackupDataResult(megolmBackupCreationInfo!!, version!!)
@@ -1402,13 +1387,11 @@ class KeysBackupTest {
     /**
      * Common initial condition
      * - Do an e2e backup to the homeserver
-     * - Log Alice on a new device
+     * - Log Alice on a new device, and wait for its keysBackup object to be ready (in state NotTrusted)
      *
      * @param password optional password
-     * @param logoutFirstAliceSession set to true to logout first Alice session before opening the second one (default is false)
      */
-    private fun createKeysBackupScenarioWithPassword(password: String?,
-                                                     logoutFirstAliceSession: Boolean = false): KeysBackupScenarioData {
+    private fun createKeysBackupScenarioWithPassword(password: String?): KeysBackupScenarioData {
         val cryptoTestData = mCryptoTestHelper.doE2ETestWithAliceAndBobInARoomWithEncryptedMessages(true)
 
         val cryptoStore = cryptoTestData.firstSession.crypto!!.cryptoStore
@@ -1437,18 +1420,19 @@ class KeysBackupTest {
 
         val aliceUserId = cryptoTestData.firstSession.myUserId
 
-        if (logoutFirstAliceSession) {
-            // Logout first Alice session, else they will share the same Crypto store and some tests may fail.
-            val latch2 = CountDownLatch(1)
-            cryptoTestData.firstSession.logout(InstrumentationRegistry.getContext(), TestApiCallback(latch2))
-            mTestHelper.await(latch2)
-        }
+        // Logout first Alice session, else they will share the same Crypto store and some tests may fail.
+        val latch2 = CountDownLatch(1)
+        cryptoTestData.firstSession.logout(InstrumentationRegistry.getContext(), TestApiCallback(latch2))
+        mTestHelper.await(latch2)
 
         // - Log Alice on a new device
         val aliceSession2 = mTestHelper.logIntoAccount(aliceUserId, defaultSessionParamsWithInitialSync)
 
         // Test check: aliceSession2 has no keys at login
         assertEquals(0, aliceSession2.crypto!!.cryptoStore.inboundGroupSessionsCount(false))
+
+        // Wait for backup state to be NotTrusted
+        waitForKeysBackupToBeInState(aliceSession2, KeysBackupStateManager.KeysBackupState.NotTrusted)
 
         stateObserver.stopAndCheckStates(null)
 

--- a/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupTest.kt
+++ b/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupTest.kt
@@ -39,6 +39,7 @@ import org.matrix.androidsdk.rest.model.keys.CreateKeysBackupVersionBody
 import org.matrix.androidsdk.rest.model.keys.KeysVersion
 import org.matrix.androidsdk.rest.model.keys.KeysVersionResult
 import org.matrix.androidsdk.util.JsonUtils
+import java.util.*
 import java.util.concurrent.CountDownLatch
 
 @RunWith(AndroidJUnit4::class)
@@ -81,7 +82,7 @@ class KeysBackupTest {
         // - Check backup keys after having marked one as backed up
         val session = sessions[0]
 
-        store.markBackupDoneForInboundGroupSessionWithId(session.mSession.sessionIdentifier(), session.mSenderKey)
+        store.markBackupDoneForInboundGroupSessions(Collections.singletonList(session))
 
         assertEquals(sessionsCount, store.inboundGroupSessionsCount(false))
         assertEquals(1, store.inboundGroupSessionsCount(true))

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXCrypto.java
@@ -45,6 +45,7 @@ import org.matrix.androidsdk.data.RoomState;
 import org.matrix.androidsdk.data.cryptostore.IMXCryptoStore;
 import org.matrix.androidsdk.listeners.IMXNetworkEventListener;
 import org.matrix.androidsdk.listeners.MXEventListener;
+import org.matrix.androidsdk.listeners.ProgressListener;
 import org.matrix.androidsdk.network.NetworkConnectivityReceiver;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
@@ -2319,12 +2320,14 @@ public class MXCrypto {
     /**
      * Import the room keys
      *
-     * @param roomKeysAsArray the room keys as array.
-     * @param password        the password
-     * @param callback        the asynchronous callback.
+     * @param roomKeysAsArray  the room keys as array.
+     * @param password         the password
+     * @param progressListener the progress listener
+     * @param callback         the asynchronous callback.
      */
     public void importRoomKeys(final byte[] roomKeysAsArray,
                                final String password,
+                               @Nullable final ProgressListener progressListener,
                                final ApiCallback<ImportRoomKeysResult> callback) {
         getDecryptingThreadHandler().post(new Runnable() {
             @Override
@@ -2370,7 +2373,7 @@ public class MXCrypto {
 
                 Log.d(LOG_TAG, "## importRoomKeys : JSON parsing " + (t2 - t1) + " ms");
 
-                importMegolmSessionsData(importedSessions, true, callback);
+                importMegolmSessionsData(importedSessions, true, progressListener, callback);
             }
         });
     }
@@ -2380,10 +2383,12 @@ public class MXCrypto {
      *
      * @param megolmSessionsData megolm sessions.
      * @param backUpKeys         true to back up them to the homeserver.
+     * @param progressListener   the progress listener
      * @param callback
      */
     public void importMegolmSessionsData(final List<MegolmSessionData> megolmSessionsData,
                                          final boolean backUpKeys,
+                                         @Nullable final ProgressListener progressListener,
                                          final ApiCallback<ImportRoomKeysResult> callback) {
         getDecryptingThreadHandler().post(new Runnable() {
             @Override
@@ -2391,10 +2396,22 @@ public class MXCrypto {
                 long t0 = System.currentTimeMillis();
 
                 final int totalNumbersOfKeys = megolmSessionsData.size();
+                int cpt = 0;
+                int lastProgress = 0;
                 int totalNumbersOfImportedKeys = 0;
 
+                if (progressListener != null) {
+                    getUIHandler().post(new Runnable() {
+                        @Override
+                        public void run() {
+                            progressListener.onProgress(0, 100);
+                        }
+                    });
+                }
 
                 for (MegolmSessionData megolmSessionData : megolmSessionsData) {
+                    cpt++;
+
                     MXOlmInboundGroupSession2 session = mOlmDevice.importInboundGroupSession(megolmSessionData);
 
                     if ((null != session) && mRoomDecryptors.containsKey(session.mRoomId)) {
@@ -2429,6 +2446,21 @@ public class MXCrypto {
                             } catch (Exception e) {
                                 Log.e(LOG_TAG, "## importRoomKeys() : onNewSession failed " + e.getMessage(), e);
                             }
+                        }
+                    }
+
+                    if (progressListener != null) {
+                        final int progress = 100 * cpt / totalNumbersOfKeys;
+
+                        if (lastProgress != progress) {
+                            lastProgress = progress;
+
+                            getUIHandler().post(new Runnable() {
+                                @Override
+                                public void run() {
+                                    progressListener.onProgress(progress, 100);
+                                }
+                            });
                         }
                     }
                 }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
@@ -560,7 +560,7 @@ public class MXOlmDevice {
                 return false;
             }
         } catch (Exception e) {
-            Log.e(LOG_TAG, "## addInboundGroupSession : sessionIdentifier') failed " + e.getMessage(), e);
+            Log.e(LOG_TAG, "## addInboundGroupSession : sessionIdentifier() failed " + e.getMessage(), e);
             return false;
         }
 
@@ -614,7 +614,7 @@ public class MXOlmDevice {
                 return null;
             }
         } catch (Exception e) {
-            Log.e(LOG_TAG, "## importInboundGroupSession : sessionIdentifier') failed " + e.getMessage(), e);
+            Log.e(LOG_TAG, "## importInboundGroupSession : sessionIdentifier() failed " + e.getMessage(), e);
             return null;
         }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
@@ -36,6 +36,8 @@ import org.matrix.olm.OlmSession;
 import org.matrix.olm.OlmUtility;
 
 import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -569,58 +571,65 @@ public class MXOlmDevice {
         session.mKeysClaimed = keysClaimed;
         session.mForwardingCurve25519KeyChain = forwardingCurve25519KeyChain;
 
-        mStore.storeInboundGroupSession(session);
+        mStore.storeInboundGroupSessions(Collections.singletonList(session));
 
         return true;
     }
 
     /**
-     * Import an inbound group session to the session store.
+     * Import an inbound group sessions to the session store.
      *
-     * @param megolmSessionData the megolm session data
-     * @return the imported session if the operation succeeds.
+     * @param megolmSessionsData the megolm sessions data
+     * @return the successfully imported sessions.
      */
     @Nullable
-    public MXOlmInboundGroupSession2 importInboundGroupSession(MegolmSessionData megolmSessionData) {
-        String sessionId = megolmSessionData.sessionId;
-        String senderKey = megolmSessionData.senderKey;
-        String roomId = megolmSessionData.roomId;
+    public List<MXOlmInboundGroupSession2> importInboundGroupSessions(List<MegolmSessionData> megolmSessionsData) {
+        List<MXOlmInboundGroupSession2> sessions = new ArrayList<>(megolmSessionsData.size());
 
-        if (null != getInboundGroupSession(sessionId, senderKey, roomId)) {
-            // If we already have this session, consider updating it
-            Log.e(LOG_TAG, "## importInboundGroupSession() : Update for megolm session " + senderKey + "/" + sessionId);
+        for (MegolmSessionData megolmSessionData : megolmSessionsData) {
 
-            // For now we just ignore updates. TODO: implement something here
-            return null;
-        }
+            String sessionId = megolmSessionData.sessionId;
+            String senderKey = megolmSessionData.senderKey;
+            String roomId = megolmSessionData.roomId;
 
-        MXOlmInboundGroupSession2 session = null;
+            if (null != getInboundGroupSession(sessionId, senderKey, roomId)) {
+                // If we already have this session, consider updating it
+                Log.e(LOG_TAG, "## importInboundGroupSession() : Update for megolm session " + senderKey + "/" + sessionId);
 
-        try {
-            session = new MXOlmInboundGroupSession2(megolmSessionData);
-        } catch (Exception e) {
-            Log.e(LOG_TAG, "## importInboundGroupSession() : Update for megolm session " + senderKey + "/" + sessionId, e);
-        }
-
-        // sanity check
-        if ((null == session) || (null == session.mSession)) {
-            Log.e(LOG_TAG, "## importInboundGroupSession : invalid session");
-            return null;
-        }
-
-        try {
-            if (!TextUtils.equals(session.mSession.sessionIdentifier(), sessionId)) {
-                Log.e(LOG_TAG, "## importInboundGroupSession : ERROR: Mismatched group session ID from senderKey: " + senderKey);
-                return null;
+                // For now we just ignore updates. TODO: implement something here
+                continue;
             }
-        } catch (Exception e) {
-            Log.e(LOG_TAG, "## importInboundGroupSession : sessionIdentifier() failed " + e.getMessage(), e);
-            return null;
+
+            MXOlmInboundGroupSession2 session = null;
+
+            try {
+                session = new MXOlmInboundGroupSession2(megolmSessionData);
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "## importInboundGroupSession() : Update for megolm session " + senderKey + "/" + sessionId, e);
+            }
+
+            // sanity check
+            if ((null == session) || (null == session.mSession)) {
+                Log.e(LOG_TAG, "## importInboundGroupSession : invalid session");
+                continue;
+            }
+
+            try {
+                if (!TextUtils.equals(session.mSession.sessionIdentifier(), sessionId)) {
+                    Log.e(LOG_TAG, "## importInboundGroupSession : ERROR: Mismatched group session ID from senderKey: " + senderKey);
+                    continue;
+                }
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "## importInboundGroupSession : sessionIdentifier() failed " + e.getMessage(), e);
+                continue;
+            }
+
+            sessions.add(session);
         }
 
-        mStore.storeInboundGroupSession(session);
+        mStore.storeInboundGroupSessions(sessions);
 
-        return session;
+        return sessions;
     }
 
     /**
@@ -684,7 +693,7 @@ public class MXOlmDevice {
                         mInboundGroupSessionMessageIndexes.get(timeline).put(messageIndexKey, true);
                     }
 
-                    mStore.storeInboundGroupSession(session);
+                    mStore.storeInboundGroupSessions(Collections.singletonList(session));
                     try {
                         JsonParser parser = new JsonParser();
                         result.mPayload = parser.parse(JsonUtils.convertFromUTF8(decryptResult.mDecryptedMessage));

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOutgoingRoomKeyRequestManager.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOutgoingRoomKeyRequestManager.java
@@ -154,6 +154,8 @@ public class MXOutgoingRoomKeyRequestManager {
             return;
         }
 
+        Log.d(LOG_TAG, "cancelRoomKeyRequest: requestId: " + req.mRequestId + " state: " + req.mState + " andResend: " + andResend);
+
         if (req.mState == OutgoingRoomKeyRequest.RequestState.CANCELLATION_PENDING
                 || req.mState == OutgoingRoomKeyRequest.RequestState.CANCELLATION_PENDING_AND_WILL_RESEND) {
             // nothing to do here

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackup.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackup.kt
@@ -1333,13 +1333,7 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
                         Log.d(LOG_TAG, "backupKeys: 5a - Request complete")
 
                         // Mark keys as backed up
-                        for (session in sessions) {
-                            try {
-                                mCrypto.cryptoStore.markBackupDoneForInboundGroupSessionWithId(session.mSession.sessionIdentifier(), session.mSenderKey)
-                            } catch (e: OlmException) {
-                                Log.e(LOG_TAG, "OlmException", e)
-                            }
-                        }
+                        mCrypto.cryptoStore.markBackupDoneForInboundGroupSessions(sessions)
 
                         if (sessions.size < KEY_BACKUP_SEND_KEYS_MAX_COUNT) {
                             Log.d(LOG_TAG, "backupKeys: All keys have been backed up")

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackup.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackup.kt
@@ -726,9 +726,8 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
                     val progressListener = if (stepProgressListener != null) {
                         object : ProgressListener {
                             override fun onProgress(progress: Int, total: Int) {
-                                mCrypto.uiHandler.post {
-                                    stepProgressListener.onStepProgress(StepProgressListener.Step.ImportingKey(progress, total))
-                                }
+                                // Note: no need to post to UI thread, importMegolmSessionsData() will do it
+                                stepProgressListener.onStepProgress(StepProgressListener.Step.ImportingKey(progress, total))
                             }
                         }
                     } else {
@@ -777,7 +776,7 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
             if (recoveryKey == null) {
                 mCrypto.uiHandler.post {
                     Log.d(LOG_TAG, "backupKeys: Invalid configuration")
-                    callback?.onUnexpectedError(IllegalStateException("Invalid configuration"))
+                    callback.onUnexpectedError(IllegalStateException("Invalid configuration"))
                 }
 
                 return@post

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackup.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackup.kt
@@ -453,6 +453,8 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
     fun trustKeysBackupVersion(keysBackupVersion: KeysVersionResult,
                                trust: Boolean,
                                callback: ApiCallback<Void>) {
+        Log.d(LOG_TAG, "trustKeyBackupVersion: $trust, version ${keysBackupVersion.version}")
+
         mCrypto.decryptingThreadHandler.post {
             val myUserId = mCrypto.myDevice.userId
 
@@ -549,6 +551,8 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
     fun trustKeysBackupVersionWithRecoveryKey(keysBackupVersion: KeysVersionResult,
                                               recoveryKey: String,
                                               callback: ApiCallback<Void>) {
+        Log.d(LOG_TAG, "trustKeysBackupVersionWithRecoveryKey: version ${keysBackupVersion.version}")
+
         mCrypto.decryptingThreadHandler.post {
             if (!isValidRecoveryKeyForKeysBackupVersion(recoveryKey, keysBackupVersion)) {
                 Log.w(LOG_TAG, "trustKeyBackupVersionWithRecoveryKey: Invalid recovery key.")
@@ -573,6 +577,8 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
     fun trustKeysBackupVersionWithPassphrase(keysBackupVersion: KeysVersionResult,
                                              password: String,
                                              callback: ApiCallback<Void>) {
+        Log.d(LOG_TAG, "trustKeysBackupVersionWithPassphrase: version ${keysBackupVersion.version}")
+
         mCrypto.decryptingThreadHandler.post {
             val recoveryKey = recoveryKeyFromPassword(password, keysBackupVersion, null)
 
@@ -1011,10 +1017,12 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
     }
 
     private fun checkAndStartWithKeysBackupVersion(keyBackupVersion: KeysVersionResult?) {
+        Log.d(LOG_TAG, "checkAndStartWithKeyBackupVersion: ${keyBackupVersion?.version}")
+
         mKeysBackupVersion = keyBackupVersion
 
         if (keyBackupVersion == null) {
-            Log.d(LOG_TAG, "checkAndStartKeysBackup: Found no key backup version on the homeserver")
+            Log.d(LOG_TAG, "checkAndStartWithKeysBackupVersion: Found no key backup version on the homeserver")
             resetKeysBackupData()
             mKeysBackupStateManager.state = KeysBackupStateManager.KeysBackupState.Disabled
         } else {
@@ -1022,7 +1030,7 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
                 val versionInStore = mCrypto.cryptoStore.keyBackupVersion
 
                 if (trustInfo.usable) {
-                    Log.d(LOG_TAG, "checkAndStartKeysBackup: Found usable key backup. version: " + keyBackupVersion.version)
+                    Log.d(LOG_TAG, "checkAndStartWithKeysBackupVersion: Found usable key backup. version: " + keyBackupVersion.version)
                     // Check the version we used at the previous app run
                     if (versionInStore != null && versionInStore != keyBackupVersion.version) {
                         Log.d(LOG_TAG, " -> clean the previously used version $versionInStore")
@@ -1032,7 +1040,7 @@ class KeysBackup(private val mCrypto: MXCrypto, session: MXSession) {
                     Log.d(LOG_TAG, "   -> enabling key backups")
                     enableKeysBackup(keyBackupVersion)
                 } else {
-                    Log.d(LOG_TAG, "checkAndStartKeysBackup: No usable key backup. version: " + keyBackupVersion.version)
+                    Log.d(LOG_TAG, "checkAndStartWithKeysBackupVersion: No usable key backup. version: " + keyBackupVersion.version)
                     if (versionInStore != null) {
                         Log.d(LOG_TAG, "   -> disabling key backup")
                         resetKeysBackupData()

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupPassword.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupPassword.kt
@@ -59,13 +59,15 @@ fun generatePrivateKeyWithPassword(password: String, progressListener: ProgressL
  * @param password the password used to generated the private key.
  * @param salt the salt.
  * @param iterations number of key derivations.
+ * @param progressListener the progress listener
  *
  * @return a private key.
  */
 fun retrievePrivateKeyWithPassword(password: String,
                                    salt: String,
-                                   iterations: Int): ByteArray {
-    return deriveKey(password, salt, iterations, null)
+                                   iterations: Int,
+                                   progressListener: ProgressListener? = null): ByteArray {
+    return deriveKey(password, salt, iterations, progressListener)
 }
 
 /**

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupPassword.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/keysbackup/KeysBackupPassword.kt
@@ -19,6 +19,7 @@
  */
 package org.matrix.androidsdk.crypto.keysbackup
 
+import android.support.annotation.WorkerThread
 import org.matrix.androidsdk.listeners.ProgressListener
 import org.matrix.androidsdk.util.Log
 import java.util.*
@@ -45,6 +46,7 @@ data class GeneratePrivateKeyResult(
  *
  * @return a {privateKey, salt, iterations} tuple.
  */
+@WorkerThread
 fun generatePrivateKeyWithPassword(password: String, progressListener: ProgressListener?): GeneratePrivateKeyResult {
     val salt = generateSalt()
     val iterations = DEFAULT_ITERATION
@@ -63,6 +65,7 @@ fun generatePrivateKeyWithPassword(password: String, progressListener: ProgressL
  *
  * @return a private key.
  */
+@WorkerThread
 fun retrievePrivateKeyWithPassword(password: String,
                                    salt: String,
                                    iterations: Int,
@@ -72,6 +75,7 @@ fun retrievePrivateKeyWithPassword(password: String,
 
 /**
  * Compute a private key by deriving a password and a salt strings.
+ *
  * @param password the password.
  * @param salt the salt.
  * @param iterations number of derivations.
@@ -79,6 +83,7 @@ fun retrievePrivateKeyWithPassword(password: String,
  *
  * @return a private key.
  */
+@WorkerThread
 private fun deriveKey(password: String,
                       salt: String,
                       iterations: Int,

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/cryptostore/IMXCryptoStore.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/cryptostore/IMXCryptoStore.java
@@ -20,6 +20,7 @@ package org.matrix.androidsdk.data.cryptostore;
 import android.content.Context;
 import android.support.annotation.Nullable;
 
+import org.jetbrains.annotations.NotNull;
 import org.matrix.androidsdk.crypto.IncomingRoomKeyRequest;
 import org.matrix.androidsdk.crypto.OutgoingRoomKeyRequest;
 import org.matrix.androidsdk.crypto.data.MXDeviceInfo;
@@ -194,11 +195,11 @@ public interface IMXCryptoStore {
     String getLastUsedSessionId(String deviceKey);
 
     /**
-     * Store an inbound group session.
+     * Store inbound group sessions.
      *
-     * @param session the inbound group session and its context.
+     * @param sessions the inbound group sessions to store.
      */
-    void storeInboundGroupSession(MXOlmInboundGroupSession2 session);
+    void storeInboundGroupSessions(@NotNull List<MXOlmInboundGroupSession2> sessions);
 
     /**
      * Retrieve an inbound group session.
@@ -235,12 +236,11 @@ public interface IMXCryptoStore {
     void resetBackupMarkers();
 
     /**
-     * Mark an inbound group session as backed up on the user homeserver.
+     * Mark inbound group sessions as backed up on the user homeserver.
      *
-     * @param sessionId the session identifier.
-     * @param senderKey the base64-encoded curve25519 key of the sender.
+     * @param sessions the sessions
      */
-    void markBackupDoneForInboundGroupSessionWithId(String sessionId, String senderKey);
+    void markBackupDoneForInboundGroupSessions(@NotNull List<MXOlmInboundGroupSession2> sessions);
 
     /**
      * Retrieve inbound group sessions that are not yet backed up.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/cryptostore/MXFileCryptoStore.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/cryptostore/MXFileCryptoStore.java
@@ -23,6 +23,7 @@ import android.os.Looper;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
+import org.jetbrains.annotations.NotNull;
 import org.matrix.androidsdk.crypto.IncomingRoomKeyRequest;
 import org.matrix.androidsdk.crypto.OutgoingRoomKeyRequest;
 import org.matrix.androidsdk.crypto.data.MXDeviceInfo;
@@ -846,50 +847,8 @@ public class MXFileCryptoStore implements IMXCryptoStore {
     }
 
     @Override
-    public void storeInboundGroupSession(final MXOlmInboundGroupSession2 session) {
-        if (!mIsReady) {
-            Log.e(LOG_TAG, "## storeInboundGroupSession() : the store is not ready");
-            return;
-        }
-
-        String sessionIdentifier = null;
-
-        if ((null != session) && (null != session.mSenderKey) && (null != session.mSession)) {
-            try {
-                sessionIdentifier = session.mSession.sessionIdentifier();
-            } catch (Exception e) {
-                Log.e(LOG_TAG, "## storeInboundGroupSession() : sessionIdentifier failed " + e.getMessage(), e);
-            }
-        }
-
-        if (null != sessionIdentifier) {
-            synchronized (mInboundGroupSessionsLock) {
-                if (!mInboundGroupSessions.containsKey(session.mSenderKey)) {
-                    mInboundGroupSessions.put(session.mSenderKey, new HashMap<String, MXOlmInboundGroupSession2>());
-                }
-
-                MXOlmInboundGroupSession2 curSession = mInboundGroupSessions.get(session.mSenderKey).get(sessionIdentifier);
-
-                if (curSession != session) {
-                    // release memory
-                    if (null != curSession) {
-                        curSession.mSession.releaseSession();
-                    }
-                    // update the map
-                    mInboundGroupSessions.get(session.mSenderKey).put(sessionIdentifier, session);
-                }
-            }
-
-            Log.d(LOG_TAG, "## storeInboundGroupSession() : store session " + sessionIdentifier);
-
-            File senderKeyFolder = new File(mInboundGroupSessionsFolder, encodeFilename(session.mSenderKey));
-
-            if (!senderKeyFolder.exists()) {
-                senderKeyFolder.mkdir();
-            }
-
-            storeObject(session, senderKeyFolder, encodeFilename(sessionIdentifier), "storeInboundGroupSession - in background");
-        }
+    public void storeInboundGroupSessions(@NotNull List<MXOlmInboundGroupSession2> sessions) {
+        // No op
     }
 
     @Override
@@ -942,7 +901,7 @@ public class MXFileCryptoStore implements IMXCryptoStore {
     }
 
     @Override
-    public void markBackupDoneForInboundGroupSessionWithId(String sessionId, String senderKey) {
+    public void markBackupDoneForInboundGroupSessions(@NotNull List<MXOlmInboundGroupSession2> sessions) {
         // No op
     }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/StepProgressListener.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/StepProgressListener.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk.listeners
+
+/**
+ * Interface to send a progress info
+ */
+interface StepProgressListener {
+
+    sealed class Step {
+        data class ComputingKey(val progress: Int, val total: Int) : Step()
+        object DownloadingKey : Step()
+        data class ImportingKey(val progress: Int, val total: Int) : Step()
+    }
+
+    /**
+     * @param step The current step, containing progress data if available. Else you should consider progress as indeterminate
+     */
+    fun onStepProgress(step: Step)
+}


### PR DESCRIPTION
This PR:
- Add check on passphrase BEFORE downloading e2e keys from Homeserver
- Add StepListener when restoring e2e keys for better UI 
- Fixes https://github.com/vector-im/riot-android/issues/2960. For 1400+ keys, importation of keys (after download) is 8 times faster (was 48_301 ms and is now 6_624 ms).