### PR TITLE
Fix  / Room v3 permalinks don't always work #8315

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bugfix:
  - Failed to send a video captured by the native camera. Replace the file scheme "file://" with "file:/" used by some Android devices.
+ - Fix / Escape room v3 event ids in permalinks (vector-im/riot-android#2981)
 
 API Change:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/util/PermalinkUtils.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/util/PermalinkUtils.java
@@ -109,12 +109,13 @@ public class PermalinkUtils {
 
     /**
      * Escape '/' in id, because it is used as a separator
+     * Escape '+' in room v3
      *
      * @param id the id to escape
      * @return the escaped id
      */
     private static String escape(String id) {
-        return id.replaceAll("/", "%2F");
+        return id.replaceAll("/", "%2F").replaceAll("\\+", "%2B");
     }
 
     /***
@@ -153,7 +154,7 @@ public class PermalinkUtils {
 
             // remove the server part
             String uriFragment;
-            if ((uriFragment = uri.getFragment()) != null) {
+            if ((uriFragment = uri.getEncodedFragment()) != null) {
                 uriFragment = uriFragment.substring(1); // get rid of first "/"
             } else {
                 Log.e(LOG_TAG, "## parseUniversalLink : cannot extract path");
@@ -161,6 +162,9 @@ public class PermalinkUtils {
             }
 
             String temp[] = uriFragment.split("/", 3); // limit to 3 for security concerns (stack overflow injection)
+            for (int i = 0; i < temp.length; i++) {
+                temp[i] = URLDecoder.decode(temp[i], "UTF-8");
+            }
 
             if (!isSupportedHost) {
                 List<String> compliantList = new ArrayList<>(Arrays.asList(temp));


### PR DESCRIPTION
Event v3 can contain +, so need to escape it when creating the permalink
+ On resolve permalink use the encoded uri fragment then split then decode
