### PR TITLE
Fix / partially shared session

### DIFF
--- a/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/common/MockOkHttpInterceptor.kt
+++ b/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/common/MockOkHttpInterceptor.kt
@@ -47,7 +47,9 @@ class MockOkHttpInterceptor : Interceptor {
 
         rules.forEach { rule ->
             if (originalRequest.url().toString().contains(rule.match)) {
-                return rule.process(originalRequest)
+                rule.process(originalRequest )?.let {
+                    return it
+                }
             }
         }
 
@@ -56,7 +58,7 @@ class MockOkHttpInterceptor : Interceptor {
 
 
     abstract class Rule(val match: String) {
-        abstract fun process(originalRequest: Request): Response
+        abstract fun process(originalRequest: Request): Response?
     }
 
     /**
@@ -66,7 +68,7 @@ class MockOkHttpInterceptor : Interceptor {
                      private val code: Int = HttpsURLConnection.HTTP_OK,
                      private val body: String = "{}") : Rule(match) {
 
-        override fun process(originalRequest: Request): Response {
+        override fun process(originalRequest: Request): Response? {
             return Response.Builder()
                     .protocol(Protocol.HTTP_1_1)
                     .request(originalRequest)

--- a/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/PartialSharedSessionTest.kt
+++ b/matrix-sdk/src/androidTest/java/org/matrix/androidsdk/crypto/PartialSharedSessionTest.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.matrix.androidsdk.crypto
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import org.junit.Assert
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
+import org.matrix.androidsdk.RestClientHttpClientFactory
+import org.matrix.androidsdk.RestHttpClientFactoryProvider
+import org.matrix.androidsdk.common.*
+import org.matrix.androidsdk.listeners.MXEventListener
+import org.matrix.androidsdk.rest.model.Event
+import org.matrix.androidsdk.util.Log
+import java.util.concurrent.CountDownLatch
+
+@RunWith(AndroidJUnit4::class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class PartialSharedSessionTest {
+
+
+    private val mTestHelper = CommonTestHelper()
+    private val mCryptoTestHelper = CryptoTestHelper(mTestHelper)
+
+
+    private val defaultSessionParamsWithInitialSync = SessionTestParams(
+            withInitialSync = true,
+            withCryptoEnabled = true,
+            withLazyLoading = false,
+            withLegacyCryptoStore = false)
+
+    @Test
+    fun testPartialSharedSession() {
+
+        var blockKeyRequests = true
+        val mockInterceptor = MockOkHttpInterceptor()
+
+        mockInterceptor.addRule(object : MockOkHttpInterceptor.Rule("_matrix/client/") {
+            override fun process(originalRequest: Request): Response? {
+                Log.e(PartialSharedSessionTest::class.java.name, "************* ${originalRequest.url().toString()}")
+                Log.e(PartialSharedSessionTest::class.java.name, "************* >> ${originalRequest.body().toString()}")
+                if (originalRequest.url().toString().contains("sendToDevice/m.room_key_request/")) {
+                    if (blockKeyRequests) {
+                        return Response.Builder()
+                                .protocol(Protocol.HTTP_1_1)
+                                .request(originalRequest)
+                                .message("mocked answer")
+                                .body(ResponseBody.create(null, "{}"))
+                                .code(200)
+                                .build()
+                    }
+                }
+                return null
+            }
+
+        })
+
+        RestHttpClientFactoryProvider.defaultProvider = RestClientHttpClientFactory(mockInterceptor)
+
+        val context = InstrumentationRegistry.getContext()
+
+        val aliceSession = mTestHelper.createAccount(TestConstants.USER_ALICE, defaultSessionParamsWithInitialSync)
+        aliceSession.credentials.deviceId = "AliceDevice"
+
+        val bobSession = mTestHelper.createAccount(TestConstants.USER_BOB, defaultSessionParamsWithInitialSync)
+        bobSession.credentials.deviceId = "BobDevice"
+
+        var roomId: String? = null
+        var latch = CountDownLatch(1)
+        aliceSession.createRoom(object : TestApiCallback<String>(latch) {
+            override fun onSuccess(info: String) {
+                roomId = info
+                super.onSuccess(info)
+            }
+        })
+        mTestHelper.await(latch)
+
+        val aliceRoom = aliceSession.dataHandler
+                .store
+                .getRoom(roomId)
+
+
+        latch = CountDownLatch(1)
+        aliceRoom.invite(bobSession.myUserId, TestApiCallback<Void>(latch))
+        mTestHelper.await(latch)
+
+        latch = CountDownLatch(1)
+        bobSession.joinRoom(roomId, TestApiCallback<String>(latch))
+        mTestHelper.await(latch)
+
+        latch = CountDownLatch(1)
+        aliceRoom
+                .enableEncryptionWithAlgorithm(MXCRYPTO_ALGORITHM_MEGOLM, TestApiCallback<Void>(latch))
+        mTestHelper.await(latch)
+
+        aliceSession.crypto!!.setWarnOnUnknownDevices(false)
+        bobSession.crypto!!.setWarnOnUnknownDevices(false)
+
+        var sentEvents = ArrayList<Event>()
+
+        val mxListener = object : MXEventListener() {
+            override fun onEventSent(event: Event?, prevEventId: String?) {
+                super.onEventSent(event, prevEventId)
+                sentEvents.add(event!!)
+            }
+        }
+        aliceRoom.dataHandler.addListener(mxListener)
+        listOf<String>("Message1", "Message2", "Message3", "Message4", "Message5").forEach {
+            val latch = CountDownLatch(1)
+            aliceRoom.sendEvent(mCryptoTestHelper.buildTextEvent(it, aliceSession, roomId!!), TestApiCallback<Void>(latch))
+            mTestHelper.await(latch)
+        }
+        aliceRoom.dataHandler.removeListener(mxListener)
+
+
+        //Now i want to log a new alice session
+
+        val aliceNewSession = mTestHelper.logIntoAccount(aliceSession.myUserId, defaultSessionParamsWithInitialSync)
+
+        var aliceRoomOtherSession = aliceNewSession.dataHandler.store.getRoom(aliceRoom.roomId)
+
+        val aliceSecondSessionEvents = sentEvents.map {
+            aliceRoomOtherSession.store.getEvent(it.eventId, aliceRoomOtherSession.roomId)
+        }
+
+        Assert.assertEquals(5, aliceSecondSessionEvents.size)
+
+        val olmSessionID = aliceSecondSessionEvents[0].contentAsJsonObject?.get("session_id")?.asString
+        Assert.assertNotNull(olmSessionID)
+        //All message are encrypted and same session, and as we have block key requests, they should be encrypted
+        aliceSecondSessionEvents.forEach {
+            assert(it.type == Event.EVENT_TYPE_MESSAGE_ENCRYPTED)
+            Assert.assertEquals(olmSessionID, it.contentAsJsonObject?.get("session_id")?.asString)
+            Assert.assertNull(it.clearEvent)
+        }
+
+        val secondMessage = aliceSecondSessionEvents[1]
+        val sessionID = secondMessage.contentAsJsonObject?.get("session_id")?.asString
+        val senderKey = secondMessage.contentAsJsonObject?.get("sender_key")?.asString
+        val osession = aliceSession.crypto?.olmDevice?.getInboundGroupSession(
+                sessionID,
+                senderKey, aliceRoom.roomId)
+
+
+        var megolmSessionData: MegolmSessionData = MegolmSessionData()
+        megolmSessionData.senderClaimedEd25519Key = osession!!.mKeysClaimed.get("ed25519")
+        megolmSessionData.forwardingCurve25519KeyChain = osession!!.mForwardingCurve25519KeyChain
+        megolmSessionData.senderKey = osession!!.mSenderKey
+        megolmSessionData.senderClaimedKeys = osession!!.mKeysClaimed
+        megolmSessionData.roomId = osession!!.mRoomId
+        megolmSessionData.sessionId = osession!!.mSession.sessionIdentifier()
+        megolmSessionData.sessionKey = osession!!.mSession.export(1)
+        megolmSessionData.algorithm = MXCRYPTO_ALGORITHM_MEGOLM
+
+
+        //import olm session in new session from index 1
+        aliceNewSession.crypto!!.olmDevice!!.importInboundGroupSessions(listOf(megolmSessionData))
+
+        val dec = aliceNewSession.crypto!!.decryptEvent(aliceRoomOtherSession.store.getLatestEvent(aliceRoom.roomId), null)
+        Assert.assertNotNull(dec)
+
+        //I should not be able do decrypt the first one
+        var first: MXEventDecryptionResult? = null
+        try {
+            first = aliceNewSession.crypto?.decryptEvent(aliceSecondSessionEvents[0], null)
+        } catch (e: MXDecryptionException) {
+
+        }
+
+        Assert.assertNull(first)
+
+        //Let's simulate a new toDevice m.forwarded_room_key event with a better session (lower chain index)
+        val toDeviceEvent = Event()
+        toDeviceEvent.type = Event.EVENT_TYPE_MESSAGE_ENCRYPTED
+        toDeviceEvent.sender = aliceSession.myUserId
+        val decryptEvent = MXEventDecryptionResult()
+        val jo = JsonObject()
+        jo.add("type", JsonPrimitive(Event.EVENT_TYPE_FORWARDED_ROOM_KEY))
+
+        decryptEvent.mClearEvent = jo
+        toDeviceEvent.setClearData(decryptEvent)
+
+        val content = JsonObject()
+
+        content.add("algorithm", JsonPrimitive(MXCRYPTO_ALGORITHM_MEGOLM))
+        content.add("session_id", JsonPrimitive(osession!!.mSession.sessionIdentifier()))
+        content.add("session_key", JsonPrimitive(osession!!.mSession.export(0)))
+        content.add("sender_claimed_ed25519_key", JsonPrimitive(osession!!.mKeysClaimed.get("ed25519")))
+        content.add("sender_key", JsonPrimitive(osession!!.mSenderKey))
+        content.add("room_id", JsonPrimitive(osession!!.mRoomId))
+
+        val sck = JsonObject()
+        sck.add("ed25519", JsonPrimitive(osession!!.mKeysClaimed.get("ed25519")))
+        content.add("sender_claimed_keys", sck)
+
+        toDeviceEvent.clearEvent.updateContent(content)
+
+
+        aliceNewSession.dataHandler.onToDeviceEvent(toDeviceEvent)
+
+
+        //We should now have received a session with an early chain index, and should be able to decrypt
+        try {
+            first = aliceNewSession.crypto?.decryptEvent(aliceSecondSessionEvents[0], null)
+        } catch (e: MXDecryptionException) {
+            Assert.assertTrue("Should be able to decrypt", false)
+        }
+
+        Assert.assertNotNull(first)
+
+        aliceSession.clear(context)
+        aliceNewSession.clear(context)
+        bobSession.clear(context)
+    }
+}

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
@@ -540,15 +540,22 @@ public class MXOlmDevice {
                                           List<String> forwardingCurve25519KeyChain,
                                           Map<String, String> keysClaimed,
                                           boolean exportFormat) {
-        if (null != getInboundGroupSession(sessionId, senderKey, roomId)) {
+        MXOlmInboundGroupSession2 existingInboundSession = getInboundGroupSession(sessionId, senderKey, roomId);
+        MXOlmInboundGroupSession2 session = new MXOlmInboundGroupSession2(sessionKey, exportFormat);
+
+        if (null != existingInboundSession) {
             // If we already have this session, consider updating it
             Log.e(LOG_TAG, "## addInboundGroupSession() : Update for megolm session " + senderKey + "/" + sessionId);
 
-            // For now we just ignore updates. TODO: implement something here
-            return false;
-        }
+            Long existingFirstKnown = existingInboundSession.getFirstKnownIndex();
+            Long newKnownFirstIndex = session.getFirstKnownIndex();
 
-        MXOlmInboundGroupSession2 session = new MXOlmInboundGroupSession2(sessionKey, exportFormat);
+            //If our existing session is better we keep it
+            if (newKnownFirstIndex != null && existingFirstKnown <= newKnownFirstIndex) {
+                session.mSession.releaseSession();
+                return false;
+            }
+        }
 
         // sanity check
         if (null == session.mSession) {
@@ -559,9 +566,11 @@ public class MXOlmDevice {
         try {
             if (!TextUtils.equals(session.mSession.sessionIdentifier(), sessionId)) {
                 Log.e(LOG_TAG, "## addInboundGroupSession : ERROR: Mismatched group session ID from senderKey: " + senderKey);
+                session.mSession.releaseSession();
                 return false;
             }
         } catch (Exception e) {
+            session.mSession.releaseSession();
             Log.e(LOG_TAG, "## addInboundGroupSession : sessionIdentifier() failed " + e.getMessage(), e);
             return false;
         }
@@ -592,14 +601,6 @@ public class MXOlmDevice {
             String senderKey = megolmSessionData.senderKey;
             String roomId = megolmSessionData.roomId;
 
-            if (null != getInboundGroupSession(sessionId, senderKey, roomId)) {
-                // If we already have this session, consider updating it
-                Log.e(LOG_TAG, "## importInboundGroupSession() : Update for megolm session " + senderKey + "/" + sessionId);
-
-                // For now we just ignore updates. TODO: implement something here
-                continue;
-            }
-
             MXOlmInboundGroupSession2 session = null;
 
             try {
@@ -617,11 +618,26 @@ public class MXOlmDevice {
             try {
                 if (!TextUtils.equals(session.mSession.sessionIdentifier(), sessionId)) {
                     Log.e(LOG_TAG, "## importInboundGroupSession : ERROR: Mismatched group session ID from senderKey: " + senderKey);
+                    if (session.mSession != null) session.mSession.releaseSession();
                     continue;
                 }
             } catch (Exception e) {
                 Log.e(LOG_TAG, "## importInboundGroupSession : sessionIdentifier() failed " + e.getMessage(), e);
+                session.mSession.releaseSession();
                 continue;
+            }
+
+            MXOlmInboundGroupSession2 existingOlmSession = getInboundGroupSession(sessionId, senderKey, roomId);
+            if (null != existingOlmSession) {
+                // If we already have this session, consider updating it
+                Log.e(LOG_TAG, "## importInboundGroupSession() : Update for megolm session " + senderKey + "/" + sessionId);
+
+                // For now we just ignore updates. TODO: implement something here
+                if (existingOlmSession.getFirstKnownIndex() <= session.getFirstKnownIndex()) {
+                    //Ignore this, keep existing
+                    session.mSession.releaseSession();
+                    continue;
+                }
             }
 
             sessions.add(session);

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/MXOlmDevice.java
@@ -552,7 +552,9 @@ public class MXOlmDevice {
 
             //If our existing session is better we keep it
             if (newKnownFirstIndex != null && existingFirstKnown <= newKnownFirstIndex) {
-                session.mSession.releaseSession();
+                if (session.mSession != null) {
+                    session.mSession.releaseSession();
+                }
                 return false;
             }
         }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/algorithms/megolm/MXMegolmDecryption.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/crypto/algorithms/megolm/MXMegolmDecryption.java
@@ -290,20 +290,22 @@ public class MXMegolmDecryption implements IMXDecrypting {
             keysClaimed = roomKeyEvent.getKeysClaimed();
         }
 
-        mOlmDevice.addInboundGroupSession(sessionId, sessionKey, roomId, senderKey, forwarding_curve25519_key_chain, keysClaimed, exportFormat);
+        boolean added = mOlmDevice.addInboundGroupSession(sessionId, sessionKey, roomId, senderKey, forwarding_curve25519_key_chain, keysClaimed, exportFormat);
 
-        mSession.getCrypto().getKeysBackup().maybeBackupKeys();
+        if (added) {
+            mSession.getCrypto().getKeysBackup().maybeBackupKeys();
 
-        RoomKeyRequestBody content = new RoomKeyRequestBody();
+            RoomKeyRequestBody content = new RoomKeyRequestBody();
 
-        content.algorithm = roomKeyContent.algorithm;
-        content.roomId = roomKeyContent.room_id;
-        content.sessionId = roomKeyContent.session_id;
-        content.senderKey = senderKey;
+            content.algorithm = roomKeyContent.algorithm;
+            content.roomId = roomKeyContent.room_id;
+            content.sessionId = roomKeyContent.session_id;
+            content.senderKey = senderKey;
 
-        mSession.getCrypto().cancelRoomKeyRequest(content);
+            mSession.getCrypto().cancelRoomKeyRequest(content);
 
-        onNewSession(senderKey, sessionId);
+            onNewSession(senderKey, sessionId);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-android/issues/3044

- Support adding/importing new version of known olm session if chain index lower (if pre racheted key has been imported earlier).
- Added some missing jni release
- Prevent a potential infinite loop of key sharing request when received key not accepted (new session event was fired even if key was not accepted, thus firing again key share requests)
