### PR TITLE
Fix / don't error if we don't know about some keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bugfix:
  - Fix replies showing mxids instead of display names (vector-im/riot-android#2468)
+ - Fix / SAS, don't error if we don't know about some keys (vector-im/riot-android#3184)
 
 API Change:
  -


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-android/issues/3184

>This is needed for compatibility with cross-signing, because with cross-signing, the client will be asked to verify the cross-signing key, but current clients don't know how to do that, so they should just ignore it rather than failing.