### PR TITLE
Fix room creation params: add the missing `state_key` in the `initial…

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/CreateRoomParams.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/CreateRoomParams.java
@@ -133,6 +133,7 @@ public class CreateRoomParams {
             Map<String, String> contentMap = new HashMap<>();
             contentMap.put("algorithm", algorithm);
             algoEvent.updateContent(JsonUtils.getGson(false).toJsonTree(contentMap));
+            algoEvent.stateKey = "";
 
             if (null == initialStates) {
                 initialStates = Arrays.asList(algoEvent);
@@ -170,6 +171,7 @@ public class CreateRoomParams {
             Map<String, String> contentMap = new HashMap<>();
             contentMap.put("history_visibility", historyVisibility);
             historyVisibilityEvent.updateContent(JsonUtils.getGson(false).toJsonTree(contentMap));
+            historyVisibilityEvent.stateKey = "";
 
             if (null == initialStates) {
                 initialStates = Arrays.asList(historyVisibilityEvent);


### PR DESCRIPTION
…_state` events.

- The expected format of the state events are an object with type, state_key and content keys set.
- This was not an actual bug, because a default state_key  (A zero-length string) is added by the server

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-android-sdk/blob/develop/CHANGES.rst)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
