### PR TITLE
Emoji verification name discrepancy between riot-web and riotX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ API Change:
  -
 
 Translations:
- -
+ - Emoji verification name discrepancy between riot-web and riotX (vector-im/riotX-android#355)
 
 Others:
  - Remove ParentRestClient from crypto module and use a common parent Rest Client (dinsic-pim/tchap-android#539)

--- a/matrix-sdk-crypto/src/main/res/values/strings.xml
+++ b/matrix-sdk-crypto/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Those strings are overidden in matrix sdk module for translations -->
+    <!-- Those strings are overridden in matrix sdk module for translations -->
     <string name="verification_emoji_dog">Dog</string>
     <string name="verification_emoji_cat">Cat</string>
     <string name="verification_emoji_lion">Lion</string>

--- a/matrix-sdk/src/main/res/values-en-rUS/strings.xml
+++ b/matrix-sdk/src/main/res/values-en-rUS/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Note to translator: please add here only the string which are different than default version (which is en-rGB) -->
+
+    <string name="verification_emoji_wrench">Wrench</string>
+    <string name="verification_emoji_airplane">Airplane</string>
+
+</resources>
+
+


### PR DESCRIPTION
 Part of vector-im/riotX-android#355

### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-android-sdk/blob/develop/CHANGES.rst)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)
