### PR TITLE
Registration Params: restore the `bind_email` option which is deprecated

### DIFF
--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/login/RegistrationParams.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/login/RegistrationParams.java
@@ -36,4 +36,9 @@ public class RegistrationParams {
     // Temporary flag to notify the server that we support msisdn flow. Used to prevent old app
     // versions to end up in fallback because the HS returns the msisdn flow which they don't support
     public Boolean x_show_msisdn;
+
+    // optional email binding: If true, the server binds the email used for authentication
+    // to the Matrix ID with the identity server.
+    @Deprecated
+    public Boolean bind_email;
 }


### PR DESCRIPTION
This option may still be used with former versions of HS
