### PR TITLE
Feature/widget permissions 3377

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@ Changes to Matrix Android SDK in 0.9.X (2019-XX-XX)
 =======================================================
 
 Features:
- -
+ - Integrations / Manage Widget Permissions in Account Data
 
 Improvements:
- - Integration Manager preferences are now manage by SDK
+ - Integration Manager preferences are now managed by SDK
 
 Bugfix:
  - Crash on Realm crypto DB (vector-im/riot-android#3373)

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/features/integrationmanager/IntegrationManager.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/features/integrationmanager/IntegrationManager.kt
@@ -48,6 +48,7 @@ class IntegrationManager(val mxSession: MXSession, val context: Context) {
             val stateEventId: String,
             val allowed: Boolean
     )
+
     /**
      * Return the identity server url, either from AccountData if it has been set, or from the local storage
      * This could return a non null value even if integrationAllowed is false, so always check integrationAllowed
@@ -163,7 +164,12 @@ class IntegrationManager(val mxSession: MXSession, val context: Context) {
                 //Check if there has been a changes in that list
                 val hasChanges = (widgetPermissions + allowedWidgetList)
                         .groupBy { it.stateEventId }
-                        .any { it.value.size == 1 }
+                        .any {
+                            //If size is one, that means that this event is in one list but not in the other
+                            it.value.size == 1
+                                    // If event is in the 2 lists but with different allowed state
+                                    || it.value[0].allowed != it.value[1].allowed
+                        }
 
                 if (hasChanges) {
                     widgetPermissions = allowedWidgetList

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/features/integrationmanager/IntegrationManager.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/features/integrationmanager/IntegrationManager.kt
@@ -114,16 +114,8 @@ class IntegrationManager(val mxSession: MXSession, val context: Context) {
                     override fun onSuccess(info: Void?) {
                         //optimistic update
                         widgetPermissions =
-                                widgetPermissions.filter { it.stateEventId == stateEventId }
-                                        .takeIf { it.isNotEmpty() }
-                                        ?.map {
-                                            // If found, modify it
-                                            it.copy(allowed = allowed)
-                                        }
-                                        ?: run {
-                                            // Else add it
-                                            widgetPermissions + listOf(WidgetPermission(stateEventId, allowed))
-                                        }
+                                // Remove existing perm for current widget if any, then add updated state
+                                widgetPermissions.filterNot { it.stateEventId == stateEventId } + listOf(WidgetPermission(stateEventId, allowed))
                         notifyListeners()
                         callback?.onSuccess(null)
                     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountDataElement.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/sync/AccountDataElement.java
@@ -32,6 +32,7 @@ public class AccountDataElement implements Serializable {
     public static final String ACCOUNT_DATA_TYPE_ACCEPTED_TERMS = "m.accepted_terms";
     public static final String ACCOUNT_DATA_TYPE_IDENTITY_SERVER = "m.identity_server";
     public static final String ACCOUNT_DATA_TYPE_INTEGRATION_PROVISIONING = "im.vector.setting.integration_provisioning";
+    public static final String ACCOUNT_DATA_TYPE_ALLOWED_WIDGETS = "im.vector.setting.allowed_widgets";
 
     /**
      * Account data known possible values for key in {@link #content}


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-android/issues/3377

Support ACCOUNT_DATA_TYPE_ALLOWED_WIDGETS account data element, and add capability to Integration Manager to manage widget permissions