### PR TITLE
MSC2437: Store tagged events in Room Account Data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changes to Matrix Android SDK in 0.9.34 (2020-XX-XX)
 =======================================================
 
 Features:
- -
+ - MSC2437: Store tagged events in Room Account Data
 
 Improvements:
  - Enhance the room account data API naming.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXDataHandler.java
@@ -2027,6 +2027,10 @@ public class MXDataHandler implements CryptoDataHandler, DataHandlerInterface {
         mMxEventDispatcher.dispatchOnRoomTagEvent(roomId, ignoreEvent(roomId));
     }
 
+    public void onTaggedEventsEvent(final String roomId) {
+        mMxEventDispatcher.dispatchOnTaggedEventsEvent(roomId, ignoreEvent(roomId));
+    }
+
     public void onReadMarkerEvent(final String roomId) {
         mMxEventDispatcher.dispatchOnReadMarkerEvent(roomId, ignoreEvent(roomId));
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MxEventDispatcher.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MxEventDispatcher.java
@@ -464,6 +464,27 @@ import java.util.Set;
         });
     }
 
+    public void dispatchOnTaggedEventsEvent(final String roomId, boolean ignoreEvent) {
+        if (ignoreEvent) {
+            return;
+        }
+
+        final List<IMXEventListener> eventListeners = getListenersSnapshot();
+
+        mUiHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                for (IMXEventListener listener : eventListeners) {
+                    try {
+                        listener.onTaggedEventsEvent(roomId);
+                    } catch (Exception e) {
+                        Log.e(LOG_TAG, "onTaggedEventsEvent " + e.getMessage(), e);
+                    }
+                }
+            }
+        });
+    }
+
     public void dispatchOnReadMarkerEvent(final String roomId, boolean ignoreEvent) {
         if (ignoreEvent) {
             return;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/core/JsonUtils.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/core/JsonUtils.java
@@ -45,6 +45,7 @@ import org.matrix.androidsdk.rest.model.RoomPinnedEventsContent;
 import org.matrix.androidsdk.rest.model.RoomTags;
 import org.matrix.androidsdk.rest.model.RoomTombstoneContent;
 import org.matrix.androidsdk.rest.model.StateEvent;
+import org.matrix.androidsdk.rest.model.TaggedEventsContent;
 import org.matrix.androidsdk.rest.model.User;
 import org.matrix.androidsdk.rest.model.bingrules.Condition;
 import org.matrix.androidsdk.rest.model.login.RegistrationFlowResponse;
@@ -455,6 +456,17 @@ public class JsonUtils {
      */
     public static RoomPinnedEventsContent toRoomPinnedEventsContent(final JsonElement jsonElement) {
         return toClass(jsonElement, RoomPinnedEventsContent.class);
+    }
+
+    /**
+     * Convert a JSON object to a TaggedEventsContent.
+     * The result is never null.
+     *
+     * @param jsonObject the json to convert
+     * @return a TaggedEventsContent
+     */
+    public static TaggedEventsContent toTaggedEventsContent(JsonElement jsonObject) {
+        return toClass(jsonObject, TaggedEventsContent.class);
     }
 
     /**

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/Room.java
@@ -71,6 +71,8 @@ import org.matrix.androidsdk.rest.model.PowerLevels;
 import org.matrix.androidsdk.rest.model.ReceiptData;
 import org.matrix.androidsdk.rest.model.RoomDirectoryVisibility;
 import org.matrix.androidsdk.rest.model.RoomMember;
+import org.matrix.androidsdk.rest.model.TaggedEventInfo;
+import org.matrix.androidsdk.rest.model.TaggedEventsContent;
 import org.matrix.androidsdk.rest.model.TokensChunkEvents;
 import org.matrix.androidsdk.rest.model.UserIdAndReason;
 import org.matrix.androidsdk.rest.model.message.FileInfo;
@@ -1951,11 +1953,19 @@ public class Room implements CryptoRoom {
     private void handleRoomAccountDataEvents(List<Event> accountDataEvents) {
         if ((null != accountDataEvents) && (accountDataEvents.size() > 0)) {
             // manage the account events
-            for (Event accountDataEvent : accountDataEvents) {
-                String eventType = accountDataEvent.getType();
+            final RoomSummary summary = (null != getStore()) ? getStore().getSummary(getRoomId()) : null;
 
-                final RoomSummary summary = (null != getStore()) ? getStore().getSummary(getRoomId()) : null;
-                if (eventType.equals(Event.EVENT_TYPE_READ_MARKER)) {
+            for (Event accountDataEvent : accountDataEvents) {
+                mAccountData.handleEvent(accountDataEvent);
+
+                String eventType = accountDataEvent.getType();
+                if (eventType.equals(Event.EVENT_TYPE_TAGS)) {
+                    if (summary != null) {
+                        summary.setRoomTags(mAccountData.getRoomTagsKeys());
+                        getStore().flushSummary(summary);
+                    }
+                    mDataHandler.onRoomTagEvent(getRoomId());
+                } else if (eventType.equals(Event.EVENT_TYPE_READ_MARKER)) {
                     if (summary != null) {
                         final Event event = JsonUtils.toEvent(accountDataEvent.getContent());
                         if (null != event && !TextUtils.equals(event.eventId, summary.getReadMarkerEventId())) {
@@ -1968,15 +1978,8 @@ public class Room implements CryptoRoom {
                             mDataHandler.onReadMarkerEvent(getRoomId());
                         }
                     }
-                } else {
-                    mAccountData.handleEvent(accountDataEvent);
-                    if (Event.EVENT_TYPE_TAGS.equals(accountDataEvent.getType())) {
-                        if (summary != null) {
-                            summary.setRoomTags(mAccountData.getRoomTagsKeys());
-                            getStore().flushSummary(summary);
-                        }
-                        mDataHandler.onRoomTagEvent(getRoomId());
-                    }
+                } else if (eventType.equals(Event.EVENT_TYPE_TAGGED_EVENTS)) {
+                    mDataHandler.onTaggedEventsEvent(getRoomId());
                 }
             }
 
@@ -2069,6 +2072,44 @@ public class Room implements CryptoRoom {
      */
     public void setIsURLPreviewAllowedByUser(boolean status, ApiCallback<Void> callback) {
         mDataHandler.getDataRetriever().getRoomsRestClient().updateURLPreviewStatus(mMyUserId, getRoomId(), status, callback);
+    }
+
+    //==============================================================================================================
+    // Tagged events
+    //==============================================================================================================
+
+    /**
+     * Tag an event of the room
+     *
+     * @param event    the event to tag
+     * @param tag      the wanted tag
+     * @param keywords the potential keywords
+     * @param callback the asynchronous callback
+     */
+    public void tagEvent(final Event event, String tag, @Nullable List<String> keywords, ApiCallback<Void> callback) {
+        final JsonObject eventContent = getAccountData().eventContent(Event.EVENT_TYPE_TAGGED_EVENTS);
+        final TaggedEventsContent taggedEventContent = JsonUtils.toTaggedEventsContent(eventContent);
+
+        TaggedEventInfo info = TaggedEventInfo.Companion.with(keywords, event.originServerTs, System.currentTimeMillis());
+        taggedEventContent.tagEvent(event.eventId, info, tag);
+
+        mDataHandler.getDataRetriever().getRoomsRestClient().updateTaggedEvents(mMyUserId, getRoomId(), taggedEventContent, callback);
+    }
+
+    /**
+     * Remove a tag applied on an event of the room
+     *
+     * @param event    the event to untag
+     * @param tag      the wanted tag
+     * @param callback the asynchronous callback
+     */
+    public void untagEvent(final Event event, String tag, ApiCallback<Void> callback) {
+        final JsonObject eventContent = getAccountData().eventContent(Event.EVENT_TYPE_TAGGED_EVENTS);
+        final TaggedEventsContent taggedEventContent = JsonUtils.toTaggedEventsContent(eventContent);
+
+        taggedEventContent.untagEvent(event.eventId, tag);
+
+        mDataHandler.getDataRetriever().getRoomsRestClient().updateTaggedEvents(mMyUserId, getRoomId(), taggedEventContent, callback);
     }
 
     //==============================================================================================================

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomSummary.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomSummary.java
@@ -70,7 +70,8 @@ public class RoomSummary implements java.io.Serializable {
             Event.EVENT_TYPE_URL_PREVIEW,
             Event.EVENT_TYPE_STATE_RELATED_GROUPS,
             Event.EVENT_TYPE_STATE_ROOM_GUEST_ACCESS,
-            Event.EVENT_TYPE_REDACTION);
+            Event.EVENT_TYPE_REDACTION,
+            Event.EVENT_TYPE_TAGGED_EVENTS);
 
     private String mRoomId = null;
     private String mTopic = null;

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/fragments/MatrixMessageListFragment.java
@@ -297,6 +297,16 @@ public abstract class MatrixMessageListFragment<MessagesAdapter extends Abstract
             });
         }
 
+        @Override
+        public void onTaggedEventsEvent(String roomId) {
+            getUiHandler().post(new Runnable() {
+                @Override
+                public void run() {
+                    mAdapter.notifyDataSetChanged();
+                }
+            });
+        }
+
         private boolean mRefreshAfterEventsDecryption;
 
         @Override

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/IMXEventListener.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/IMXEventListener.java
@@ -202,6 +202,13 @@ public interface IMXEventListener {
     void onRoomTagEvent(String roomId);
 
     /**
+     * A tagged events event has been received.
+     *
+     * @param roomId the roomID
+     */
+    void onTaggedEventsEvent(String roomId);
+
+    /**
      * A read marker has been updated
      *
      * @param roomId thr room id.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/MXEventListener.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/MXEventListener.java
@@ -118,6 +118,10 @@ public class MXEventListener implements IMXEventListener {
     }
 
     @Override
+    public void onTaggedEventsEvent(String roomId) {
+    }
+
+    @Override
     public void onReadMarkerEvent(String roomId) {
     }
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/MXRoomEventListener.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/listeners/MXRoomEventListener.java
@@ -188,6 +188,18 @@ public class MXRoomEventListener extends MXEventListener {
     }
 
     @Override
+    public void onTaggedEventsEvent(String roomId) {
+        // Filter out events for other rooms
+        if (TextUtils.equals(mRoomId, roomId)) {
+            try {
+                mEventListener.onTaggedEventsEvent(roomId);
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "onTaggedEventsEvent exception " + e.getMessage(), e);
+            }
+        }
+    }
+
+    @Override
     public void onReadMarkerEvent(String roomId) {
         // Filter out events for other rooms
         if (TextUtils.equals(mRoomId, roomId)) {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/RoomsRestClient.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/client/RoomsRestClient.java
@@ -45,6 +45,7 @@ import org.matrix.androidsdk.rest.model.PowerLevels;
 import org.matrix.androidsdk.rest.model.ReportContentParams;
 import org.matrix.androidsdk.rest.model.RoomAliasDescription;
 import org.matrix.androidsdk.rest.model.RoomDirectoryVisibility;
+import org.matrix.androidsdk.rest.model.TaggedEventsContent;
 import org.matrix.androidsdk.rest.model.TokensChunkEvents;
 import org.matrix.androidsdk.rest.model.Typing;
 import org.matrix.androidsdk.rest.model.User;
@@ -912,6 +913,29 @@ public class RoomsRestClient extends RestClient<RoomsApi> {
                     @Override
                     public void onRetry() {
                         updateURLPreviewStatus(userId, roomId, status, callback);
+                    }
+                }));
+    }
+
+    /**
+     * Update the tagged events
+     *
+     * @param userId   the userId
+     * @param roomId   the roomId
+     * @param content  the new tagged events content
+     * @param callback the operation callback
+     */
+    public void updateTaggedEvents(final String userId, final String roomId, final TaggedEventsContent content, final ApiCallback<Void> callback) {
+        final String description = "updateTaggedEvents : roomId " + roomId;
+
+        Map<String, Object> params = new HashMap();
+        params.put(TaggedEventsContent.TAGS_KEY, content.tags);
+
+        mApi.updateAccountData(userId, roomId, Event.EVENT_TYPE_TAGGED_EVENTS, params)
+                .enqueue(new RestAdapterCallback<Void>(description, mUnsentEventsManager, callback, new RestAdapterCallback.RequestRetryCallBack() {
+                    @Override
+                    public void onRetry() {
+                        updateTaggedEvents(userId, roomId, content, callback);
                     }
                 }));
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/Event.java
@@ -110,6 +110,7 @@ public class Event implements Externalizable, CryptoEvent {
     public static final String EVENT_TYPE_TAGS = "m.tag";
     public static final String EVENT_TYPE_READ_MARKER = "m.fully_read";
     public static final String EVENT_TYPE_URL_PREVIEW = "org.matrix.room.preview_urls";
+    public static final String EVENT_TYPE_TAGGED_EVENTS = "m.tagged_events";
 
     // State events
     public static final String EVENT_TYPE_STATE_ROOM_NAME = "m.room.name";

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/TaggedEvents.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/TaggedEvents.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.matrix.androidsdk.rest.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Class used to parse the content of a m.tagged_events type event.
+ * This kind of event defines the tagged events in a room.
+ *
+ * The content of this event is a tags key whose value is an object mapping the name of each tag
+ * to another object. The JSON object associated with each tag is an object where the keys are the
+ * event IDs and values give information about the events.
+ */
+data class TaggedEventsContent (
+        @JvmField
+        @SerializedName("tags")
+        var tags: Map<String, Map<String, TaggedEventInfo>> = emptyMap()
+) {
+    fun getFavouriteEvents(): Map<String, TaggedEventInfo> {
+        return tags[TAG_FAVOURITE] ?: emptyMap()
+    }
+
+    fun getHiddenEvents(): Map<String, TaggedEventInfo> {
+        return tags[TAG_HIDDEN] ?: emptyMap()
+    }
+
+    fun tagEvent(eventId: String, info: TaggedEventInfo, tag: String) {
+        val tagMap = HashMap<String, TaggedEventInfo>(tags[tag] ?: emptyMap())
+        tagMap[eventId] = info
+
+        val updatedTags = HashMap<String, Map<String, TaggedEventInfo>>(tags)
+        updatedTags[tag] = tagMap
+        tags = updatedTags
+    }
+
+    fun untagEvent(eventId: String, tag: String) {
+        val tagMap = HashMap<String, TaggedEventInfo>(tags[tag] ?: emptyMap())
+        tagMap.remove(eventId)
+
+        val updatedTags = HashMap<String, Map<String, TaggedEventInfo>>(tags)
+        updatedTags[tag] = tagMap
+        tags = updatedTags
+    }
+
+    companion object {
+        const val TAGS_KEY = "tags"
+        const val TAG_FAVOURITE = "m.favourite"
+        const val TAG_HIDDEN = "m.hidden"
+    }
+}
+
+data class TaggedEventInfo(@JvmField
+                           @SerializedName("keywords")
+                           var keywords: List<String>? = null,
+
+                           @JvmField
+                           @SerializedName("origin_server_ts")
+                           var originServerTs: Long? = null,
+
+                           @JvmField
+                           @SerializedName("tagged_at")
+                           var taggedAt: Long? = null
+) {
+    companion object {
+        fun with(keywords: List<String>?, originServerTs: Long?, taggedAt: Long?): TaggedEventInfo {
+            return TaggedEventInfo().apply {
+                this.keywords = keywords
+                this.originServerTs = originServerTs
+                this.taggedAt = taggedAt
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Store tagged events in Room Account Data [MSC2437](https://github.com/matrix-org/matrix-doc/blob/giomfo/tagged_events/proposals/2437-tagged-events-account-data.md)
- MXEventsListener: add a method to listen to the changes on tagged events
- RoomAccountData: the full read marker info "m.fully_read" is now stored in the room account data too.
