### PR TITLE
SDK support for reading custom jitsi server configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Translations:
  -
 
 Others:
- -
+ - Provided support for implementation of reading "im.vector.riot.jitsi" from /.well-known/matrix/client
 
 Build:
  -

--- a/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
+++ b/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
@@ -38,6 +38,9 @@ import com.google.gson.annotations.SerializedName
  *              }
  *          ]
  *    }
+ *     "im.vector.riot.jitsi": {
+ *         "preferredDomain": "https://jitsi.riot.im/"
+ *     }
  * }
  * </pre>
  */
@@ -81,4 +84,8 @@ class WellKnown {
         }
         return managers
     }
+	
+	@JvmField
+    @SerializedName("im.vector.riot.jitsi")
+    var jitsiServer: WellKnownBaseConfig? = null
 }

--- a/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
+++ b/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
@@ -87,5 +87,5 @@ class WellKnown {
 
     @JvmField
     @SerializedName("im.vector.riot.jitsi")
-    var jitsiServer: WellKnownBaseConfig? = null
+    var jitsiServer: WellKnownPreferredConfig? = null
 }

--- a/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
+++ b/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
@@ -84,7 +84,7 @@ class WellKnown {
         }
         return managers
     }
-	
+
     @JvmField
     @SerializedName("im.vector.riot.jitsi")
     var jitsiServer: WellKnownBaseConfig? = null

--- a/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
+++ b/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnown.kt
@@ -85,7 +85,7 @@ class WellKnown {
         return managers
     }
 	
-	@JvmField
+    @JvmField
     @SerializedName("im.vector.riot.jitsi")
     var jitsiServer: WellKnownBaseConfig? = null
 }

--- a/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnownPreferredConfig.kt
+++ b/matrix-sdk-core/src/main/java/org/matrix/androidsdk/rest/model/WellKnownPreferredConfig.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.matrix.androidsdk.rest.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * https://matrix.org/docs/spec/client_server/r0.4.0.html#server-discovery
+ * <pre>
+ * {
+ *     "preferredDomain": "https://jitsi.riot.im/"
+ * }
+ * </pre>
+ */
+class WellKnownPreferredConfig {
+
+    @JvmField
+    @SerializedName("preferredDomain")
+    var preferredDomain: String? = null
+}
+


### PR DESCRIPTION
### Pull Request Checklist
Addressing [this issue](https://github.com/vector-im/riot-android/issues/3443): I think this is the first step for implementing the ability to read "im.vector.riot.jitsi" from /.well-known/matrix/client

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] Pull request is based on the develop branch
* [x] Pull request updates [CHANGES.rst](https://github.com/matrix-org/matrix-android-sdk/blob/develop/CHANGES.rst)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
