### PR TITLE
Fix issue with identity server (missing access token) (vector-im/riot-android#3404)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Improvements:
  - MXSession: Do not refresh TURN servers when VoIP is not supported
 
 Bugfix:
- -
+ - Fix issue with identity server (missing access token) (vector-im/riot-android#3404)
 
 API Change:
  - RoomAccountdata.hasTags() has been deprecated. Use .hasRoomTags() instead.

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/features/identityserver/IdentityServerManager.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/features/identityserver/IdentityServerManager.kt
@@ -323,14 +323,15 @@ class IdentityServerManager(val mxSession: MXSession,
 
         identityAuthRestClient?.register(requestOpenIdTokenResponse, object : SimpleApiCallback<IdentityServerRegisterResponse>(callback) {
             override fun onSuccess(info: IdentityServerRegisterResponse) {
-                if (info.identityServerAccessToken == null) {
+                val token = info.identityServerAccessToken
+                if (token == null) {
                     callback.onUnexpectedError(Exception("Missing Access Token"))
                     return
                 }
                 // Store the token for next time
-                identityServerTokensStore.setToken(mxSession.myUserId, identityServerUrl!!, info.identityServerAccessToken)
+                identityServerTokensStore.setToken(mxSession.myUserId, identityServerUrl!!, token)
 
-                callback.onSuccess(info.identityServerAccessToken)
+                callback.onSuccess(token)
             }
 
             override fun onMatrixError(e: MatrixError) {

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/identityserver/IdentityServerRegisterResponse.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/identityserver/IdentityServerRegisterResponse.kt
@@ -30,5 +30,6 @@ data class IdentityServerRegisterResponse(
         val token: String? = null
 ) {
     // XXX: The spec is `token`, but we used `access_token` for a Sydent release.
-    val identityServerAccessToken = token ?: accessToken
+    val identityServerAccessToken: String?
+        get() = token ?: accessToken
 }


### PR DESCRIPTION
Fixes vector-im/riot-android#3404
