### PR TITLE
Bug Fix - Killed Application misses some notifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  - Crypto: Only create one olm session at a time per device (vector-im/riot-android#3056).
 
 Bugfix:
- -
+ - Killed Application misses some notifications
 
 API Change:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomAccountData.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomAccountData.java
@@ -54,8 +54,8 @@ public class RoomAccountData implements java.io.Serializable {
     // The events the user wants to hide in this room.
     private Map<String, TaggedEventInfo> hiddenEvents = null;
 
-    // Store the content of all the provided events by using their event type.
-    private Map<String, JsonObject> eventContentsMap = new HashMap<>();
+    // Store all the provided events by using their event type.
+    private Map<String, Event> eventsMap = new HashMap<>();
 
     /**
      * Process an event that modifies room account data (like m.tag event).
@@ -79,13 +79,8 @@ public class RoomAccountData implements java.io.Serializable {
             hiddenEvents = taggedEventContent.getHiddenEvents();
         }
 
-        // Store by default the content of all the provided events.
-        if (jsonObject != null) {
-            eventContentsMap.put(eventType, jsonObject);
-        } else {
-            // Store an empty JsonObject
-            eventContentsMap.put(eventType, new JsonObject());
-        }
+        // Store by default all the provided events.
+        eventsMap.put(eventType, event);
     }
 
     /**
@@ -189,7 +184,11 @@ public class RoomAccountData implements java.io.Serializable {
      */
     @Nullable
     public JsonObject eventContent(String eventType) {
-        return eventContentsMap.get(eventType);
+        Event event = eventsMap.get(eventType);
+        if (event != null) {
+            return event.getContentAsJsonObject();
+        }
+        return null;
     }
 
 

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/TaggedEvents.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/TaggedEvents.kt
@@ -31,7 +31,7 @@ data class TaggedEventsContent (
         @JvmField
         @SerializedName("tags")
         var tags: Map<String, Map<String, TaggedEventInfo>> = emptyMap()
-) {
+) : Serializable {
     fun getFavouriteEvents(): Map<String, TaggedEventInfo> {
         return tags[TAG_FAVOURITE] ?: emptyMap()
     }

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/TaggedEvents.kt
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/rest/model/TaggedEvents.kt
@@ -17,6 +17,7 @@
 package org.matrix.androidsdk.rest.model
 
 import com.google.gson.annotations.SerializedName
+import java.io.Serializable
 
 /**
  * Class used to parse the content of a m.tagged_events type event.
@@ -75,7 +76,7 @@ data class TaggedEventInfo(@JvmField
                            @JvmField
                            @SerializedName("tagged_at")
                            var taggedAt: Long? = null
-) {
+) : Serializable {
     companion object {
         fun with(keywords: List<String>?, originServerTs: Long?, taggedAt: Long?): TaggedEventInfo {
             return TaggedEventInfo().apply {


### PR DESCRIPTION
When the application is killed the first push notification is never displayed.
This was due to a bug in the RoomAccountData definition. Indeed some items of this class were not Serializable.
This make fail the loading of RoomAccountData from the store on new application launch
-> The store is considered corrupted -> the stream token is reseted
The first event which awakes the app is handled during an initial sync, so no push is applied for it...