### PR TITLE
Set user id before storing it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  -
 
 Bugfix:
- - Fix a crash when it checks user preference (related to matrix-org/synapse#7606).
+ - Fix a crash when it checks user presence (related to matrix-org/synapse#7606).
 
 API Change:
  -

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Improvements:
  -
 
 Bugfix:
- -
+ - Fix a crash when it checks user preference (related to matrix-org/synapse#7606).
 
 API Change:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -547,6 +547,7 @@ public class MXSession implements CryptoSession {
                     currentUser.lastActiveAgo = user.lastActiveAgo;
                 } else {
                     currentUser = user;
+                    currentUser.user_id = userId;
                 }
 
                 currentUser.setLatestPresenceTs(System.currentTimeMillis());


### PR DESCRIPTION
Fix a crash when it checks user preference (related to matrix-org/synapse#7606)