### PR TITLE
Fix crashes related to RoomAccountData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Improvements:
 
 Bugfix:
  - Fix a crash when it checks user presence (related to matrix-org/synapse#7606).
+ - Fix crashes related to RoomAccountData (flush the store if this isn't done yet to take into account the recent added eventsMap).
 
 API Change:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/store/MXFileStore.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/store/MXFileStore.java
@@ -1868,9 +1868,15 @@ public class MXFileStore extends MXMemoryStore {
                 }
 
                 roomAccountData = (RoomAccountData) accountAsVoid;
+
+                // Patch: check whether the eventsMap exists by retrieving an event.
+                // This action will trigger an exception if this map doesn't exist.
+                // We will then flush the store to rebuild it correctly
+                roomAccountData.eventContent(Event.EVENT_TYPE_READ_MARKER);
             }
         } catch (Exception e) {
             succeeded = false;
+            roomAccountData = null;
             Log.e(LOG_TAG, "loadRoomAccountData failed : " + e.toString(), e);
         }
 


### PR DESCRIPTION
Flush the store if this isn't done yet to take into account the recent added eventsMap