### PR TITLE
Improve the push rules handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,17 @@ Features:
 
 Improvements:
  - MXWebRtcCall: improve the mIsSupported flag handling.
+ - Improve/Simplify the push rules handling.
 
 Bugfix:
  - Fix a crash when it checks user presence (related to matrix-org/synapse#7606).
 
 API Change:
- -
+ - MXDataHandler: refreshPushRules() has been removed - we trust the server sync response
+ - BingRulesManager: loadRules() has been removed - we trust the server sync response
+ - BingRulesManager: an update of the push rules is not forced anymore when a rule is deleted, added or updated.
+ We let the server sync handle this push rules update.
+ - BingRulesManager: the interface onBingRulesUpdateListener has been removed. Use MXEventListener instead.
 
 Translations:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/MXSession.java
@@ -349,7 +349,7 @@ public class MXSession implements CryptoSession {
         mDataHandler.setNetworkConnectivityReceiver(mNetworkConnectivityReceiver);
         mContext.registerReceiver(mNetworkConnectivityReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
 
-        mBingRulesManager = new BingRulesManager(this, mNetworkConnectivityReceiver);
+        mBingRulesManager = new BingRulesManager(this);
         mDataHandler.setPushRulesManager(mBingRulesManager);
 
         mUnsentEventsManager = new UnsentEventsManager(mNetworkConnectivityReceiver, mDataHandler);


### PR DESCRIPTION
- Consider only the push rules data retrieved thanks to the server sync response
- Initialize the BingRulesManager with the stored push rules, instead of request them to the server
- Do not use anymore the C-S request to get the push rules directly (This is useless)
- Remove "onBingRulesUpdateListener" from BingRulesManager, it was not used

API Change:
- MXDataHandler: refreshPushRules() has been removed - we trust the server sync response
- BingRulesManager: loadRules() has been removed - we trust the server sync response
- BingRulesManager: an update of the push rules is not forced anymore when a rule is deleted, added or updated.
We let the server sync handle this push rules update.
- BingRulesManager: the interface onBingRulesUpdateListener has been removed. Use MXEventListener instead.