### PR TITLE
Fix Crash: java.lang.NullPointerException: at org.matrix.androidsdk.data.RoomState.getMembersAsync

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Improvements:
 Bugfix:
  - Fix a crash when it checks user presence (related to matrix-org/synapse#7606).
  - Fix crashes related to RoomAccountData (flush the store if this isn't done yet to take into account the recent added eventsMap).
- - Fix a crash java.lang.NullPointerException: Attempt to invoke virtual method 'void org.matrix.androidsdk.MXDataHandler.getMembersAsync' on a null object reference
+ - Fix a crash: java.lang.NullPointerException: at org.matrix.androidsdk.data.RoomState.getMembersAsync
 
 API Change:
  -

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Improvements:
 Bugfix:
  - Fix a crash when it checks user presence (related to matrix-org/synapse#7606).
  - Fix crashes related to RoomAccountData (flush the store if this isn't done yet to take into account the recent added eventsMap).
+ - Fix a crash java.lang.NullPointerException: Attempt to invoke virtual method 'void org.matrix.androidsdk.MXDataHandler.getMembersAsync' on a null object reference
 
 API Change:
  -

--- a/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomState.java
+++ b/matrix-sdk/src/main/java/org/matrix/androidsdk/data/RoomState.java
@@ -294,7 +294,7 @@ public class RoomState implements Externalizable, CryptoRoomState {
                 doTheRequest = mGetAllMembersCallbacks.size() == 1;
             }
 
-            if (doTheRequest) {
+            if (doTheRequest && getDataHandler() != null) {
                 // Load members from server
                 getDataHandler().getMembersAsync(roomId, new ApiCallback<List<RoomMember>>() {
                     @Override


### PR DESCRIPTION
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.matrix.androidsdk.MXDataHandler.getMembersAsync(java.lang.String, org.matrix.androidsdk.core.callback.ApiCallback)' on a null object reference
at org.matrix.androidsdk.data.RoomState.getMembersAsync(RoomState.java:299)

see https://github.com/dinsic-pim/tchap-android/issues/680

This crash seems due to an unexpected race condition